### PR TITLE
OAuth2 소셜 로그인 및 JWT 인증/인가 구현 

### DIFF
--- a/src/main/java/com/example/dzipsa/DzipsaApplication.java
+++ b/src/main/java/com/example/dzipsa/DzipsaApplication.java
@@ -2,8 +2,10 @@ package com.example.dzipsa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DzipsaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/dzipsa/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/controller/AuthController.java
@@ -1,0 +1,140 @@
+package com.example.dzipsa.domain.auth.controller;
+
+import com.example.dzipsa.domain.auth.dto.request.RefreshTokenRequest;
+import com.example.dzipsa.domain.auth.dto.response.AccessTokenResponse;
+import com.example.dzipsa.domain.auth.dto.response.TokenResponse;
+import com.example.dzipsa.domain.auth.service.AuthService;
+import com.example.dzipsa.domain.user.dto.response.UserResponse;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.domain.user.service.UserService;
+import com.example.dzipsa.global.exception.dto.ErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Auth", description = "인증 관련 API (로그인, 로그아웃, 토큰 재발급 등)")
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final UserService userService;
+
+    @GetMapping("/check")
+    @Operation(summary = "Access Token 유효성 검증", description = "헤더의 Access Token이 유효한지 검증합니다. 유효하면 200 OK, 아니면 401 Unauthorized를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 유효함"),
+            @ApiResponse(responseCode = "401", description = "토큰 만료 또는 유효하지 않음", 
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> check(
+            @Parameter(hidden = true) @AuthenticationPrincipal User user) {
+        log.info("[AuthController] check 요청 user={}", user != null ? user.getId() : "unknown");
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 재발급", description = "쿠키의 Refresh Token을 사용하여 새로운 Access Token을 발급합니다. (Rotation: Refresh Token도 갱신됨)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "재발급 성공 (Body: Access Token, Cookie: Refresh Token)"),
+            @ApiResponse(responseCode = "401", description = "Refresh Token이 없거나 유효하지 않음", 
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AccessTokenResponse> refresh(
+            @Parameter(description = "Refresh Token (Cookie)", required = false) 
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        log.info("[AuthController] refresh 요청");
+
+        if (refreshToken == null) {
+            log.warn("[AuthController] refresh 실패 - 쿠키에 refreshToken 없음");
+            return ResponseEntity.status(401).build();
+        }
+
+        String oldAccessToken = resolveToken(request);
+        TokenResponse tokenResponse = authService.refresh(new RefreshTokenRequest(refreshToken), oldAccessToken);
+
+        // Refresh Token 쿠키 설정 (Rotation 적용)
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokenResponse.getRefreshToken())
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(14 * 24 * 60 * 60) // 14일
+                .build();
+
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        // Access Token은 응답 바디로 반환
+        AccessTokenResponse accessTokenResponse = AccessTokenResponse.builder()
+                .accessToken(tokenResponse.getAccessToken())
+                .build();
+
+        return ResponseEntity.ok(accessTokenResponse);
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "Refresh Token 삭제 및 Access Token 블랙리스트 처리")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    })
+    public ResponseEntity<Void> logout(
+            @Parameter(description = "Refresh Token (Cookie)", required = false)
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletRequest request) {
+        log.info("[AuthController] logout 요청");
+        String accessToken = resolveToken(request);
+        // refreshToken이 쿠키에 없어도 로그아웃은 진행 (Access Token 블랙리스트 처리는 해야 하므로)
+        authService.logout(refreshToken, accessToken);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", 
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<UserResponse> me(
+            @Parameter(hidden = true) @AuthenticationPrincipal User user) {
+        log.info("[AuthController] me 요청 user={}", user != null ? user.getId() : "null");
+        if (user == null) {
+            log.warn("[AuthController] me 인증 없음");
+            return ResponseEntity.status(401).build();
+        }
+        UserResponse response = userService.findById(user.getId());
+        return ResponseEntity.ok(response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/controller/DevLoginController.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/controller/DevLoginController.java
@@ -1,0 +1,56 @@
+package com.example.dzipsa.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Tag(name = "Auth (Dev)", description = "개발용 로그인 페이지")
+@Controller
+public class DevLoginController {
+
+    @GetMapping("/login")
+    @ResponseBody
+    @Operation(summary = "개발용 소셜 로그인 페이지", description = "백엔드 테스트를 위한 소셜 로그인 버튼이 있는 HTML 페이지를 반환합니다. 브라우저 주소창에 /login을 입력하여 접속하세요.")
+    public String login() {
+        return """
+            <!DOCTYPE html>
+            <html lang="ko">
+            <head>
+                <meta charset="UTF-8">
+                <title>Dzipsa 로그인 (개발용)</title>
+                <style>
+                    body {
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100vh;
+                        flex-direction: column;
+                        font-family: Arial, sans-serif;
+                    }
+                    h2 { margin-bottom: 20px; }
+                    .btn {
+                        display: block;
+                        width: 200px;
+                        padding: 10px;
+                        margin: 10px;
+                        text-align: center;
+                        text-decoration: none;
+                        border-radius: 5px;
+                        color: white;
+                        font-weight: bold;
+                    }
+                    .naver { background-color: #03C75A; }
+                    .kakao { background-color: #FEE500; color: #000; }
+                </style>
+            </head>
+            <body>
+                <h2>Dzipsa 소셜 로그인</h2>
+                <a href="/oauth2/authorization/naver" class="btn naver">네이버 로그인</a>
+                <a href="/oauth2/authorization/kakao" class="btn kakao">카카오 로그인</a>
+            </body>
+            </html>
+            """;
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,20 @@
+package com.example.dzipsa.domain.auth.converter;
+
+import com.example.dzipsa.domain.auth.dto.response.TokenResponse;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthConverter {
+
+    private static final String GRANT_TYPE = "Bearer";
+
+    public TokenResponse toTokenResponse(String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        return TokenResponse.builder()
+                .grantType(GRANT_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn)
+                .build();
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/dto/info/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/dto/info/KakaoOAuth2UserInfo.java
@@ -1,0 +1,45 @@
+package com.example.dzipsa.domain.auth.dto.info;
+
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+    }
+
+    @Override
+    public String getNickname() {
+        if (profile != null && profile.get("nickname") != null) {
+            return (String) profile.get("nickname");
+        }
+        return "Unknown_Kakao";
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/dto/info/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/dto/info/NaverOAuth2UserInfo.java
@@ -1,0 +1,43 @@
+package com.example.dzipsa.domain.auth.dto.info;
+
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> response;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.response = (Map<String, Object>) attributes.get("response");
+        if (this.response == null) {
+            throw new IllegalStateException("Naver 응답에 response가 없습니다.");
+        }
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) response.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) response.get("nickname");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/dto/info/OAuth2UserInfo.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/dto/info/OAuth2UserInfo.java
@@ -1,0 +1,16 @@
+package com.example.dzipsa.domain.auth.dto.info;
+
+import java.util.Map;
+
+public interface OAuth2UserInfo {
+
+    String getProviderId();
+
+    String getProvider();
+
+    String getEmail();
+
+    String getNickname();
+
+    Map<String, Object> getAttributes();
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,18 @@
+package com.example.dzipsa.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshTokenRequest {
+
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,14 @@
+package com.example.dzipsa.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,18 @@
+package com.example.dzipsa.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/entity/OAuthAccount.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/entity/OAuthAccount.java
@@ -1,0 +1,55 @@
+package com.example.dzipsa.domain.auth.entity;
+
+import com.example.dzipsa.domain.auth.entity.enums.OAuthProvider;
+import com.example.dzipsa.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "oauth_accounts",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 20)
+    private OAuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false, length = 100)
+    private String providerId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,45 @@
+package com.example.dzipsa.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 512)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public boolean isExpired(LocalDateTime now) {
+        return now.isAfter(expiredAt);
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/entity/enums/OAuthProvider.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/entity/enums/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.example.dzipsa.domain.auth.entity.enums;
+
+public enum OAuthProvider {
+    NAVER,
+    KAKAO
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/entity/enums/ProviderType.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/entity/enums/ProviderType.java
@@ -1,0 +1,6 @@
+package com.example.dzipsa.domain.auth.entity.enums;
+
+public enum ProviderType {
+    NAVER,
+    KAKAO
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/repository/OAuthAccountRepository.java
@@ -1,0 +1,15 @@
+package com.example.dzipsa.domain.auth.repository;
+
+import com.example.dzipsa.domain.auth.entity.OAuthAccount;
+import com.example.dzipsa.domain.auth.entity.enums.OAuthProvider;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
+
+    Optional<OAuthAccount> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+
+    Optional<OAuthAccount> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.example.dzipsa.domain.auth.repository;
+
+import com.example.dzipsa.domain.auth.entity.RefreshToken;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/service/AuthService.java
@@ -1,0 +1,116 @@
+package com.example.dzipsa.domain.auth.service;
+
+import com.example.dzipsa.domain.auth.converter.AuthConverter;
+import com.example.dzipsa.domain.auth.dto.request.RefreshTokenRequest;
+import com.example.dzipsa.domain.auth.dto.response.TokenResponse;
+import com.example.dzipsa.domain.auth.entity.RefreshToken;
+import com.example.dzipsa.domain.auth.repository.RefreshTokenRepository;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.domain.user.repository.UserRepository;
+import com.example.dzipsa.global.exception.BusinessException;
+import com.example.dzipsa.global.exception.domain.AuthErrorCode;
+import com.example.dzipsa.global.exception.domain.UserErrorCode;
+import com.example.dzipsa.global.redis.RedisUtil;
+import com.example.dzipsa.global.security.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private static final int REFRESH_TOKEN_VALID_DAYS = 14;
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthConverter authConverter;
+    private final RedisUtil redisUtil;
+
+    @Transactional
+    public TokenResponse issueTokenResponse(User user) {
+        log.debug("[AuthService] issueTokenResponse userId={}", user.getId());
+        String accessToken = jwtTokenProvider.createAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole()
+        );
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole()
+        );
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        LocalDateTime now = LocalDateTime.now();
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(user.getId())
+                .token(refreshToken)
+                .createdAt(now)
+                .expiredAt(now.plusDays(REFRESH_TOKEN_VALID_DAYS))
+                .build());
+
+        Long accessTokenExpiresIn = jwtTokenProvider.getAccessTokenExpirationMs();
+        return authConverter.toTokenResponse(accessToken, refreshToken, accessTokenExpiresIn);
+    }
+
+    @Transactional
+    public TokenResponse refresh(RefreshTokenRequest request, String oldAccessToken) {
+        log.info("[AuthService] refresh 요청");
+        if (!jwtTokenProvider.validateRefreshToken(request.getRefreshToken())) {
+            log.warn("[AuthService] refresh 실패 - 토큰 유효성 실패");
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        RefreshToken storedToken = refreshTokenRepository.findByToken(request.getRefreshToken())
+                .orElseThrow(() -> {
+                    log.warn("[AuthService] refresh 실패 - 저장된 토큰 없음");
+                    return new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+                });
+
+        User user = userRepository.findById(storedToken.getUserId())
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+        refreshTokenRepository.delete(storedToken);
+
+        // 기존 Access Token을 Blacklist에 추가 (유효한 경우에만)
+        if (StringUtils.hasText(oldAccessToken) && jwtTokenProvider.validateAccessToken(oldAccessToken)) {
+            Date expiration = jwtTokenProvider.getExpirationDateFromAccessToken(oldAccessToken);
+            long expirationTime = (expiration.getTime() - System.currentTimeMillis()) / 1000 / 60;
+            if (expirationTime > 0) {
+                redisUtil.setBlackList(oldAccessToken, "refresh", expirationTime);
+                log.info("[AuthService] 기존 Access Token 블랙리스트 처리 완료");
+            }
+        }
+
+        return issueTokenResponse(user);
+    }
+
+    @Transactional
+    public void logout(String refreshToken, String accessToken) {
+        log.info("[AuthService] logout 요청");
+        
+        // 1. Refresh Token 삭제
+        refreshTokenRepository.findByToken(refreshToken)
+                .ifPresent(refreshTokenRepository::delete);
+
+        // 2. Access Token Blacklist 처리
+        if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateAccessToken(accessToken)) {
+            Date expiration = jwtTokenProvider.getExpirationDateFromAccessToken(accessToken);
+            long expirationTime = (expiration.getTime() - System.currentTimeMillis()) / 1000 / 60;
+            if (expirationTime > 0) {
+                redisUtil.setBlackList(accessToken, "logout", expirationTime);
+                log.info("[AuthService] Access Token 블랙리스트 처리 완료 (logout)");
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,105 @@
+package com.example.dzipsa.domain.auth.service;
+
+import com.example.dzipsa.domain.auth.dto.info.KakaoOAuth2UserInfo;
+import com.example.dzipsa.domain.auth.dto.info.NaverOAuth2UserInfo;
+import com.example.dzipsa.domain.auth.dto.info.OAuth2UserInfo;
+import com.example.dzipsa.domain.auth.entity.OAuthAccount;
+import com.example.dzipsa.domain.auth.entity.enums.OAuthProvider;
+import com.example.dzipsa.domain.auth.entity.enums.ProviderType;
+import com.example.dzipsa.domain.auth.repository.OAuthAccountRepository;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.domain.user.entity.enums.UserStatus;
+import com.example.dzipsa.domain.user.repository.UserRepository;
+import com.example.dzipsa.global.security.CustomPrincipal;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final OAuthAccountRepository oauthAccountRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 소셜 확인 (naver, kakao)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("[CustomOAuth2UserService] loadUser registrationId={}", registrationId);
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        OAuth2UserInfo oAuth2UserInfo = createOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
+
+        // 신규 가입 여부를 확인하기 위한 변수
+        AtomicBoolean isNewUser = new AtomicBoolean(false);
+
+        User user = saveOrUpdate(oAuth2UserInfo, isNewUser);
+
+        log.info("[CustomOAuth2UserService] loadUser 완료 userId={}, provider={}, isNewUser={}", 
+                user.getId(), registrationId, isNewUser.get());
+
+        return new CustomPrincipal(user, oAuth2User.getAttributes(), isNewUser.get());
+    }
+
+    private OAuth2UserInfo createOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId.toLowerCase()) {
+            case "naver" -> new NaverOAuth2UserInfo(attributes);
+            case "kakao" -> new KakaoOAuth2UserInfo(attributes);
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다. ID: " + registrationId);
+        };
+    }
+
+    private User saveOrUpdate(OAuth2UserInfo userInfo, AtomicBoolean isNewUser) {
+        OAuthProvider provider = OAuthProvider.valueOf(userInfo.getProvider().toUpperCase());
+
+        return oauthAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+                .map(OAuthAccount::getUser)
+                .map(user -> {
+                    log.debug("[CustomOAuth2UserService] 기존 OAuth 계정 로그인 userId={}", user.getId());
+                    return user;
+                })
+                .orElseGet(() -> {
+                    isNewUser.set(true); // 신규 생성 시 true 설정
+                    return createUserAndOAuthAccount(userInfo, provider);
+                });
+    }
+
+    private User createUserAndOAuthAccount(OAuth2UserInfo userInfo, OAuthProvider provider) {
+        String email = userInfo.getEmail();
+
+        String nickname = userInfo.getNickname();
+
+        User newUser = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .status(UserStatus.ACTIVE)
+                .providerType(ProviderType.valueOf(userInfo.getProvider().toUpperCase()))
+                .build();
+        userRepository.save(newUser);
+
+        OAuthAccount newAccount = OAuthAccount.builder()
+                .user(newUser)
+                .provider(provider)
+                .providerId(userInfo.getProviderId())
+                .createdAt(LocalDateTime.now())
+                .build();
+        oauthAccountRepository.save(newAccount);
+        log.info("[CustomOAuth2UserService] 신규 OAuth 가입 완료 userId={}, provider={}", newUser.getId(), provider);
+
+        return newUser;
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/dzipsa/domain/user/converter/UserConverter.java
@@ -1,0 +1,21 @@
+package com.example.dzipsa.domain.user.converter;
+
+import com.example.dzipsa.domain.user.dto.response.UserResponse;
+import com.example.dzipsa.domain.user.entity.User;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserConverter {
+
+    public UserResponse toResponse(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .providerType(user.getProviderType())
+                .profileImageUrl(user.getProfileImageUrl())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,23 @@
+package com.example.dzipsa.domain.user.dto.response;
+
+import com.example.dzipsa.domain.auth.entity.enums.ProviderType;
+import com.example.dzipsa.domain.user.entity.enums.UserRole;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private ProviderType providerType;
+    private String profileImageUrl;
+    private UserRole role;
+}

--- a/src/main/java/com/example/dzipsa/domain/user/entity/User.java
+++ b/src/main/java/com/example/dzipsa/domain/user/entity/User.java
@@ -1,0 +1,92 @@
+package com.example.dzipsa.domain.user.entity;
+
+import com.example.dzipsa.domain.auth.entity.enums.ProviderType;
+import com.example.dzipsa.domain.user.entity.enums.UserRole;
+import com.example.dzipsa.domain.user.entity.enums.UserStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    private String profileImageUrl;
+
+    private boolean terms_agreed;
+
+    private boolean marketing_agreed;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ProviderType providerType;
+
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public User(String email, String nickname, UserStatus status, UserRole role,
+        ProviderType providerType) {
+        this.email = email;
+        this.nickname = nickname;
+        this.status = status != null ? status : UserStatus.ACTIVE;
+        this.role = role != null ? role : UserRole.USER;
+        this.providerType = providerType;
+    }
+
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/user/entity/enums/UserRole.java
+++ b/src/main/java/com/example/dzipsa/domain/user/entity/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.dzipsa.domain.user.entity.enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/example/dzipsa/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/com/example/dzipsa/domain/user/entity/enums/UserStatus.java
@@ -1,0 +1,7 @@
+package com.example.dzipsa.domain.user.entity.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    DELETED
+}

--- a/src/main/java/com/example/dzipsa/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.example.dzipsa.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.dzipsa.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/example/dzipsa/domain/user/service/UserService.java
+++ b/src/main/java/com/example/dzipsa/domain/user/service/UserService.java
@@ -1,0 +1,44 @@
+package com.example.dzipsa.domain.user.service;
+
+import com.example.dzipsa.domain.user.converter.UserConverter;
+import com.example.dzipsa.domain.user.dto.response.UserResponse;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.domain.user.repository.UserRepository;
+import com.example.dzipsa.global.exception.BusinessException;
+import com.example.dzipsa.global.exception.domain.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserConverter userConverter;
+
+    public UserResponse findById(Long userId) {
+        log.debug("[UserService] findById userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("[UserService] findById 실패 - 사용자 없음 userId={}", userId);
+                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                });
+        return userConverter.toResponse(user);
+    }
+
+    public UserResponse findByEmail(String email) {
+        log.debug("[UserService] findByEmail email={}", email);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn("[UserService] findByEmail 실패 - 사용자 없음 email={}", email);
+                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                });
+        return userConverter.toResponse(user);
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/config/JwtProperties.java
+++ b/src/main/java/com/example/dzipsa/global/config/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.example.dzipsa.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String accessSecret;
+    private String refreshSecret;
+    private long accessTokenExpiration = 1_800_000L;   // 30분
+    private long refreshTokenExpiration = 604_800_000L; // 7일
+}

--- a/src/main/java/com/example/dzipsa/global/config/RedisConfig.java
+++ b/src/main/java/com/example/dzipsa/global/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.example.dzipsa.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key Serializer: String
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value Serializer: JSON (GenericJackson2JsonRedisSerializer)
+        // 어떤 객체든 JSON 형태로 저장하고, 가져올 때도 해당 객체로 변환해줌
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+        GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        redisTemplate.setValueSerializer(jsonRedisSerializer);
+        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dzipsa/global/config/SecurityConfig.java
@@ -1,0 +1,92 @@
+package com.example.dzipsa.global.config;
+
+import com.example.dzipsa.domain.auth.service.CustomOAuth2UserService;
+import com.example.dzipsa.global.security.CustomAuthenticationEntryPoint;
+import com.example.dzipsa.global.security.JwtAuthenticationFilter;
+import com.example.dzipsa.global.security.OAuth2LoginFailureHandler;
+import com.example.dzipsa.global.security.OAuth2LoginSuccessHandler;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+            .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 비활성화
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/api/auth/refresh",
+                    "/api/auth/logout",
+                    "/login", // 개발용 로그인 페이지 허용
+                    "/oauth2/**",
+                    "/favicon.ico",
+                    "/error",
+                    "/css/**", "/images/**", "/js/**"
+                ).permitAll()
+                .requestMatchers(
+                    "/h2-console/**"
+                ).permitAll()
+                .requestMatchers(
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
+                .anyRequest().authenticated())
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(customAuthenticationEntryPoint))
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                .successHandler(oAuth2LoginSuccessHandler)
+                .failureHandler(oAuth2LoginFailureHandler))
+            .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/exception/domain/AuthErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/AuthErrorCode.java
@@ -14,7 +14,8 @@ public enum AuthErrorCode implements ApiCode {
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 존재하는 이메일입니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), 401, "아이디 또는 비밀번호가 잘못되었습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), 401, "유효하지 않은 리프레시 토큰입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED.value(), 401, "로그인이 필요합니다.");
 
     private final Integer httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/dzipsa/global/redis/RedisUtil.java
+++ b/src/main/java/com/example/dzipsa/global/redis/RedisUtil.java
@@ -1,0 +1,38 @@
+package com.example.dzipsa.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // Key Prefixes
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
+
+    // --- Blacklist (Auth) ---
+
+    public void setBlackList(String accessToken, String value, long expirationMinutes) {
+        redisTemplate.opsForValue().set(
+                BLACKLIST_PREFIX + accessToken, 
+                value, 
+                expirationMinutes, 
+                TimeUnit.MINUTES
+        );
+    }
+
+    public boolean hasKeyBlackList(String accessToken) {
+        return redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken);
+    }
+
+    public Object getBlackList(String accessToken) {
+        return redisTemplate.opsForValue().get(BLACKLIST_PREFIX + accessToken);
+    }
+
+}

--- a/src/main/java/com/example/dzipsa/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/dzipsa/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package com.example.dzipsa.global.security;
+
+import com.example.dzipsa.global.exception.domain.AuthErrorCode;
+import com.example.dzipsa.global.exception.dto.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        log.warn("[CustomAuthenticationEntryPoint] 인증 실패: uri={}, message={}", request.getRequestURI(), authException.getMessage());
+
+        AuthErrorCode errorCode = AuthErrorCode.UNAUTHORIZED_ACCESS;
+        
+        // 생성자를 사용하여 객체 생성
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/security/CustomPrincipal.java
+++ b/src/main/java/com/example/dzipsa/global/security/CustomPrincipal.java
@@ -1,0 +1,44 @@
+package com.example.dzipsa.global.security;
+
+import com.example.dzipsa.domain.user.entity.User;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import lombok.Getter;
+
+@Getter
+public class CustomPrincipal implements OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+    private final boolean isNewUser; // 신규 가입 여부 추가
+
+    public CustomPrincipal(User user, Map<String, Object> attributes, boolean isNewUser) {
+        this.user = user;
+        this.attributes = attributes != null ? attributes : Collections.emptyMap();
+        this.isNewUser = isNewUser;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
+    }
+
+    @Override
+    public String getName() {
+        return user.getEmail();
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/dzipsa/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,86 @@
+package com.example.dzipsa.global.security;
+
+import com.example.dzipsa.domain.user.repository.UserRepository;
+import com.example.dzipsa.global.redis.RedisUtil;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ACCESS_TOKEN_COOKIE = "accessToken";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final RedisUtil redisUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateAccessToken(token)) {
+            // Redis Blacklist 확인
+            if (redisUtil.hasKeyBlackList(token)) {
+                log.warn("[JwtAuthenticationFilter] 블랙리스트에 등록된 토큰입니다.");
+                // 여기서 401을 줄 수도 있지만, Security 흐름상 그냥 넘기면 
+                // 뒤의 인증 과정에서 SecurityContext에 인증 정보가 없으므로 
+                // EntryPoint에서 401(또는 로그인 페이지 리다이렉트) 처리됩니다.
+            } else {
+                Long userId = jwtTokenProvider.getUserIdFromAccessToken(token);
+                userRepository.findById(userId).ifPresent(user -> {
+                    List<SimpleGrantedAuthority> authorities = Collections.singletonList(
+                            new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+                    );
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(user, null, authorities);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                });
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        // 1. 헤더에서 검색
+        String bearer = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearer) && bearer.startsWith(BEARER_PREFIX)) {
+            return bearer.substring(BEARER_PREFIX.length());
+        }
+
+        // 2. 쿠키에서 검색 (헤더에 없을 경우)
+        if (request.getCookies() != null) {
+            return Arrays.stream(request.getCookies())
+                    .filter(cookie -> ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/dzipsa/global/security/JwtTokenProvider.java
@@ -1,0 +1,117 @@
+package com.example.dzipsa.global.security;
+
+import com.example.dzipsa.domain.user.entity.enums.UserRole;
+import com.example.dzipsa.global.config.JwtProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String TOKEN_TYPE_ACCESS = "access";
+    private static final String TOKEN_TYPE_REFRESH = "refresh";
+    private static final String CLAIM_USER_ID = "userId";
+    private static final String CLAIM_EMAIL = "email";
+    private static final String CLAIM_ROLE = "role";
+    private static final String CLAIM_TYPE = "type";
+
+    private final JwtProperties jwtProperties;
+
+    public String createAccessToken(Long userId, String email, UserRole role) {
+        return createToken(
+                userId,
+                email,
+                role,
+                TOKEN_TYPE_ACCESS,
+                jwtProperties.getAccessSecret(),
+                jwtProperties.getAccessTokenExpiration()
+        );
+    }
+
+    public String createRefreshToken(Long userId, String email, UserRole role) {
+        return createToken(
+                userId,
+                email,
+                role,
+                TOKEN_TYPE_REFRESH,
+                jwtProperties.getRefreshSecret(),
+                jwtProperties.getRefreshTokenExpiration()
+        );
+    }
+
+    private String createToken(Long userId, String email, UserRole role, String type,
+                               String secret, long expirationMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim(CLAIM_EMAIL, email)
+                .claim(CLAIM_ROLE, role.name())
+                .claim(CLAIM_TYPE, type)
+                .claim(CLAIM_USER_ID, userId)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getUserIdFromAccessToken(String token) {
+        Claims claims = parseToken(token, jwtProperties.getAccessSecret());
+        return claims.get(CLAIM_USER_ID, Long.class);
+    }
+
+    public boolean validateAccessToken(String token) {
+        return validateToken(token, jwtProperties.getAccessSecret(), TOKEN_TYPE_ACCESS);
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return validateToken(token, jwtProperties.getRefreshSecret(), TOKEN_TYPE_REFRESH);
+    }
+
+    public Long getUserIdFromRefreshToken(String token) {
+        Claims claims = parseToken(token, jwtProperties.getRefreshSecret());
+        return claims.get(CLAIM_USER_ID, Long.class);
+    }
+
+    private boolean validateToken(String token, String secret, String expectedType) {
+        try {
+            Claims claims = parseToken(token, secret);
+            String type = claims.get(CLAIM_TYPE, String.class);
+            return expectedType.equals(type);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims parseToken(String token, String secret) {
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public long getAccessTokenExpirationMs() {
+        return jwtProperties.getAccessTokenExpiration();
+    }
+
+    // 토큰의 만료 시간을 Date 객체로 반환하는 메서드 추가
+    public Date getExpirationDateFromAccessToken(String token) {
+        return parseToken(token, jwtProperties.getAccessSecret()).getExpiration();
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/security/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/example/dzipsa/global/security/OAuth2LoginFailureHandler.java
@@ -1,0 +1,36 @@
+package com.example.dzipsa.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${app.oauth2.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        log.error("[OAuth2LoginFailureHandler] 소셜 로그인 실패: {}", exception.getMessage());
+
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("error", "oauth2_login_failed")
+                .queryParam("message", exception.getMessage())
+                .build()
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/dzipsa/global/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,59 @@
+package com.example.dzipsa.global.security;
+
+import com.example.dzipsa.domain.auth.dto.response.TokenResponse;
+import com.example.dzipsa.domain.auth.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+
+    @Value("${app.oauth2.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
+        TokenResponse tokenResponse = authService.issueTokenResponse(principal.getUser());
+
+
+        // Refresh Token 쿠키 설정 (httpOnly=true, Secure=true, SameSite=None)
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokenResponse.getRefreshToken())
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(7 * 24 * 60 * 60) // 7일
+                .build();
+
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        // 신규 가입 여부, Access Token 파라미터 추가
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", tokenResponse.getAccessToken())
+                .queryParam("created", principal.isNewUser())
+                .build()
+                .toUriString();
+
+        log.info("[OAuth2LoginSuccessHandler] 로그인 성공, created={}, 리다이렉트: {}", principal.isNewUser(), targetUrl);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#4 
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

- SecurityConfig: JWT 필터, OAuth2(Naver, Kakao), CORS, 글로벌 예외 처리 구성
- Auth: 로그인(Success/Failure Handler), 로그아웃(Redis Blacklist), 토큰 재발급(Rotation) 구현
- User: User 및 OAuthAccount 엔티티, 관련 Repository/Service 추가
- Infrastructure: Redis 설정(Serializer) 및 JPA Auditing 활성화
- 로컬 테스트용 소셜 로그인 페이지(DevLoginController) 추가

## 🛠️ 주요 변경 사항 및 리팩토링


## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
