### PR TITLE
회원 탈퇴 및 재가입 기능 구현

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/controller/AuthController.java
@@ -28,6 +28,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -110,6 +111,32 @@ public class AuthController {
         response.addHeader("Set-Cookie", cookieUtil.deleteRefreshTokenCookie().toString());
 
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴", description = "회원 정보를 비활성화하고 관련 토큰을 모두 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> withdraw(
+            @Parameter(hidden = true) @AuthenticationPrincipal User user,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        log.info("[AuthController] withdraw 요청 user={}", user != null ? user.getId() : "null");
+        if (user == null) {
+            log.warn("[AuthController] withdraw 인증 없음");
+            return ResponseEntity.status(401).build();
+        }
+        String accessToken = resolveToken(request);
+
+        authService.withdraw(user.getId(), accessToken);
+
+        // 쿠키 삭제
+        response.addHeader("Set-Cookie", cookieUtil.deleteRefreshTokenCookie().toString());
+
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/example/dzipsa/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.example.dzipsa.domain.auth.converter.AuthConverter;
 import com.example.dzipsa.domain.auth.dto.request.RefreshTokenRequest;
 import com.example.dzipsa.domain.auth.dto.response.TokenResponse;
 import com.example.dzipsa.domain.auth.entity.RefreshToken;
+import com.example.dzipsa.domain.auth.repository.OAuthAccountRepository;
 import com.example.dzipsa.domain.auth.repository.RefreshTokenRepository;
 import com.example.dzipsa.domain.user.entity.User;
 import com.example.dzipsa.domain.user.entity.enums.UserRole;
@@ -33,6 +34,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final OAuthAccountRepository oAuthAccountRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthConverter authConverter;
     private final RedisUtil redisUtil;
@@ -106,5 +108,33 @@ public class AuthService {
                 log.info("[AuthService] Access Token 블랙리스트 처리 완료 (logout)");
             }
         }
+    }
+
+    @Transactional
+    public void withdraw(Long userId, String accessToken) {
+        log.info("[AuthService] withdraw 요청 userId={}", userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 1. 소셜 연동 정보 삭제 (재가입을 위해)
+        oAuthAccountRepository.findByUserId(userId).ifPresent(oAuthAccountRepository::delete);
+
+        // 2. 리프레시 토큰 삭제
+        refreshTokenRepository.deleteByUserId(userId);
+
+        // 3. 유저 상태 변경 (논리적 삭제)
+        user.withdraw();
+
+        // 4. Access Token Blacklist 처리
+        if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateAccessToken(accessToken)) {
+            Date expiration = jwtTokenProvider.getExpirationDateFromAccessToken(accessToken);
+            long expirationTime = (expiration.getTime() - System.currentTimeMillis()) / 1000 / 60;
+            if (expirationTime > 0) {
+                redisUtil.setBlackList(accessToken, "withdraw", expirationTime);
+                log.info("[AuthService] Access Token 블랙리스트 처리 완료 (withdraw)");
+            }
+        }
+        log.info("[AuthService] 회원 탈퇴 처리 완료. userId={}", userId);
     }
 }

--- a/src/main/java/com/example/dzipsa/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/service/CustomOAuth2UserService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
@@ -37,19 +38,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // 소셜 확인 (naver, kakao)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         log.info("[CustomOAuth2UserService] loadUser registrationId={}", registrationId);
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
         OAuth2UserInfo oAuth2UserInfo = createOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
 
-        // 신규 가입 여부를 확인하기 위한 변수
         AtomicBoolean isNewUser = new AtomicBoolean(false);
-
         User user = saveOrUpdate(oAuth2UserInfo, isNewUser);
 
-        log.info("[CustomOAuth2UserService] loadUser 완료 userId={}, provider={}, isNewUser={}", 
+        log.info("[CustomOAuth2UserService] loadUser 완료 userId={}, provider={}, isNewUser={}",
                 user.getId(), registrationId, isNewUser.get());
 
         return new CustomPrincipal(user, oAuth2User.getAttributes(), isNewUser.get());
@@ -66,40 +64,69 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private User saveOrUpdate(OAuth2UserInfo userInfo, AtomicBoolean isNewUser) {
         OAuthProvider provider = OAuthProvider.valueOf(userInfo.getProvider().toUpperCase());
 
-        return oauthAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
-                .map(OAuthAccount::getUser)
-                .map(user -> {
-                    log.debug("[CustomOAuth2UserService] 기존 OAuth 계정 로그인 userId={}", user.getId());
-                    return user;
-                })
-                .orElseGet(() -> {
-                    isNewUser.set(true); // 신규 생성 시 true 설정
-                    return createUserAndOAuthAccount(userInfo, provider);
-                });
+        // 1. provider와 providerId로 OAuthAccount를 찾는다. (가장 정확한 식별 방법)
+        Optional<OAuthAccount> oauthAccountOpt = oauthAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId());
+
+        if (oauthAccountOpt.isPresent()) {
+            // 1-1. OAuthAccount가 존재하면, 기존 유저이므로 로그인 처리
+            log.debug("[CustomOAuth2UserService] 기존 OAuth 계정 로그인 userId={}", oauthAccountOpt.get().getUser().getId());
+            return oauthAccountOpt.get().getUser();
+        } else {
+            // 1-2. OAuthAccount가 없으면, 신규 가입 또는 재가입
+            return handleNewOrRejoiningUser(userInfo, provider, isNewUser);
+        }
+    }
+
+    private User handleNewOrRejoiningUser(OAuth2UserInfo userInfo, OAuthProvider provider, AtomicBoolean isNewUser) {
+        ProviderType providerType = ProviderType.valueOf(userInfo.getProvider().toUpperCase());
+        
+        // 2. 이메일과 ProviderType으로 기존 유저가 있는지 확인한다.
+        Optional<User> userOpt = userRepository.findByEmailAndProviderType(userInfo.getEmail(), providerType);
+
+        if (userOpt.isPresent()) {
+            User existingUser = userOpt.get();
+            // 2-1. 이메일과 Provider가 모두 일치하고, 상태가 DELETED인 경우 -> 재가입 처리
+            if (existingUser.getStatus() == UserStatus.DELETED) {
+                log.info("[CustomOAuth2UserService] 탈퇴한 사용자 재가입 처리. userId={}", existingUser.getId());
+                existingUser.rejoin(userInfo.getNickname());
+                createOAuthAccount(existingUser, provider, userInfo.getProviderId());
+                return existingUser;
+            }
+            // 2-2. 그 외의 경우 (논리적으로는 발생하기 어려움. OAuthAccount가 없는데 User는 있는 경우)
+            // 혹시 모를 데이터 불일치 상황에 대비해, 기존 계정에 OAuth 정보만 추가해준다.
+            log.warn("[CustomOAuth2UserService] 데이터 불일치 의심: User는 존재하나 OAuthAccount가 없음. userId={}", existingUser.getId());
+            createOAuthAccount(existingUser, provider, userInfo.getProviderId());
+            return existingUser;
+        } else {
+            // 3. 완전히 새로운 유저인 경우 (이메일이 같더라도 Provider가 다르면 여기에 해당) -> 신규 가입 처리
+            isNewUser.set(true);
+            return createUserAndOAuthAccount(userInfo, provider);
+        }
     }
 
     private User createUserAndOAuthAccount(OAuth2UserInfo userInfo, OAuthProvider provider) {
-        String email = userInfo.getEmail();
-
-        String nickname = userInfo.getNickname();
-
+        log.info("[CustomOAuth2UserService] 신규 사용자 가입 처리. email={}, provider={}", userInfo.getEmail(), provider.name());
         User newUser = User.builder()
-                .email(email)
-                .nickname(nickname)
+                .email(userInfo.getEmail())
+                .nickname(userInfo.getNickname())
                 .status(UserStatus.ACTIVE)
                 .providerType(ProviderType.valueOf(userInfo.getProvider().toUpperCase()))
                 .build();
         userRepository.save(newUser);
 
+        createOAuthAccount(newUser, provider, userInfo.getProviderId());
+
+        return newUser;
+    }
+
+    private void createOAuthAccount(User user, OAuthProvider provider, String providerId) {
         OAuthAccount newAccount = OAuthAccount.builder()
-                .user(newUser)
+                .user(user)
                 .provider(provider)
-                .providerId(userInfo.getProviderId())
+                .providerId(providerId)
                 .createdAt(LocalDateTime.now())
                 .build();
         oauthAccountRepository.save(newAccount);
-        log.info("[CustomOAuth2UserService] 신규 OAuth 가입 완료 userId={}, provider={}", newUser.getId(), provider);
-
-        return newUser;
+        log.info("[CustomOAuth2UserService] OAuth 계정 생성/연결 완료. userId={}, provider={}", user.getId(), provider);
     }
 }

--- a/src/main/java/com/example/dzipsa/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/dzipsa/domain/user/converter/UserConverter.java
@@ -15,6 +15,7 @@ public class UserConverter {
                 .nickname(user.getNickname())
                 .providerType(user.getProviderType())
                 .profileImageUrl(user.getProfileImageUrl())
+                .terms_agreed(user.isTerms_agreed())
                 .role(user.getRole())
                 .build();
     }

--- a/src/main/java/com/example/dzipsa/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/user/dto/response/UserResponse.java
@@ -20,4 +20,6 @@ public class UserResponse {
     private ProviderType providerType;
     private String profileImageUrl;
     private UserRole role;
+    private boolean terms_agreed;
+
 }

--- a/src/main/java/com/example/dzipsa/domain/user/entity/User.java
+++ b/src/main/java/com/example/dzipsa/domain/user/entity/User.java
@@ -36,7 +36,8 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    // unique = true 제거됨
+    @Column(nullable = false, length = 100)
     private String email;
 
     @Column(nullable = false, length = 50)
@@ -53,8 +54,6 @@ public class User {
     private String profileImageUrl;
 
     private boolean terms_agreed;
-
-    private boolean marketing_agreed;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
@@ -87,6 +86,17 @@ public class User {
     public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void withdraw() {
+        this.status = UserStatus.DELETED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void rejoin(String nickname) {
+        this.status = UserStatus.ACTIVE;
+        this.nickname = nickname;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/dzipsa/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/user/repository/UserRepository.java
@@ -1,14 +1,17 @@
 package com.example.dzipsa.domain.user.repository;
 
-import java.util.Optional;
-
+import com.example.dzipsa.domain.auth.entity.enums.ProviderType;
+import com.example.dzipsa.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.example.dzipsa.domain.user.entity.User;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    // 재가입 확인용: 이메일과 ProviderType이 모두 일치하는 사용자 조회
+    Optional<User> findByEmailAndProviderType(String email, ProviderType providerType);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/example/dzipsa/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dzipsa/global/config/SecurityConfig.java
@@ -41,15 +41,15 @@ public class SecurityConfig {
         http
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
-            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
-            .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 비활성화
+            .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화 (DevLoginController가 /login 처리)
+            .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                     "/api/auth/refresh",
                     "/api/auth/logout",
-                    "/login", // 개발용 로그인 페이지 허용
+                    "/login",    // DevLoginController 접근 허용
                     "/oauth2/**",
                     "/favicon.ico",
                     "/error",
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 ).permitAll()
                 .anyRequest().authenticated())
             .exceptionHandling(exception -> exception
-                .authenticationEntryPoint(customAuthenticationEntryPoint))
+                .authenticationEntryPoint(customAuthenticationEntryPoint)) // 인증 실패 시 401 JSON 응답
             .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                 .successHandler(oAuth2LoginSuccessHandler)

--- a/src/main/java/com/example/dzipsa/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dzipsa/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -43,5 +44,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(code.getHttpStatus())
                 .body(new ErrorResponse(code.getCode(), code.getMessage()));
+    }
+
+    // favicon.ico 등 정적 리소스를 찾을 수 없는 경우 무시 (로그 출력 안 함)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Void> handleNoResourceFoundException(NoResourceFoundException e) {
+        return ResponseEntity.notFound().build();
     }
 }


### PR DESCRIPTION

## 🔗 관련 이슈
> e.g. Close #이슈번호

#12 
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

- User: 회원 상태 변경 메서드(withdraw, rejoin) 추가, Email 유니크 제약 및 마케팅 동의 필드 제거
- Auth: 회원 탈퇴 API 구현 (Soft Delete, Refresh Token 삭제, Access Token 블랙리스트 처리)
- OAuth2: 로그인 로직 개선 (탈퇴한 회원 재가입 처리, 기존 계정 연동 확인)
- Global: NoResourceFoundException 핸들러 추가 (favicon.ico 404 로그 무시)

## 🛠️ 주요 변경 사항 및 리팩토링


## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
