### PR TITLE
사용자 관련 API 및 프로필 관리 기능 추가

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/dzipsa/domain/user/controller/UserController.java
@@ -1,0 +1,56 @@
+package com.example.dzipsa.domain.user.controller;
+
+import com.example.dzipsa.domain.user.dto.request.UpdateProfileRequest;
+import com.example.dzipsa.domain.user.dto.response.ProfileImageResponse;
+import com.example.dzipsa.domain.user.dto.response.UserResponse;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.domain.user.service.UserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Users", description = "사용자 관련 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me/profile-image")
+    @Operation(summary = "내 프로필 사진 조회", description = "로그인한 사용자의 프로필 이미지 URL을 조회합니다.")
+    public ResponseEntity<ProfileImageResponse> getMyProfileImage(
+            @AuthenticationPrincipal User user) {
+        ProfileImageResponse response = userService.getProfileImage(user.getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/me/terms-agreement")
+    @Operation(summary = "이용약관 동의", description = "로그인한 사용자의 이용약관 동의 여부를 true로 변경합니다.")
+    public ResponseEntity<Void> agreeTerms(
+            @AuthenticationPrincipal User user) {
+        userService.agreeTerms(user.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me")
+    @Operation(summary = "내 정보 수정", description = "로그인한 사용자의 닉네임과 프로필 이미지를 수정합니다.")
+    public ResponseEntity<UserResponse> updateMyProfile(
+            @Valid @RequestBody UpdateProfileRequest request,
+            @AuthenticationPrincipal User user) {
+        UserResponse response = userService.updateProfile(user.getId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/dzipsa/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/dzipsa/domain/user/converter/UserConverter.java
@@ -1,5 +1,6 @@
 package com.example.dzipsa.domain.user.converter;
 
+import com.example.dzipsa.domain.user.dto.response.ProfileImageResponse;
 import com.example.dzipsa.domain.user.dto.response.UserResponse;
 import com.example.dzipsa.domain.user.entity.User;
 
@@ -15,9 +16,15 @@ public class UserConverter {
                 .nickname(user.getNickname())
                 .providerType(user.getProviderType())
                 .profileImageUrl(user.getProfileImageUrl())
-                .terms_agreed(user.isTerms_agreed())
+                .termsAgreed(user.isTermsAgreed())
                 .role(user.getRole())
                 .hasRoom(hasRoom)
+                .build();
+    }
+
+    public ProfileImageResponse toProfileImageResponse(User user) {
+        return ProfileImageResponse.builder()
+                .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/example/dzipsa/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/example/dzipsa/domain/user/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,19 @@
+package com.example.dzipsa.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateProfileRequest {
+
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 50자 이하로 입력해주세요.")
+    @Schema(description = "새 닉네임", example = "멋쟁이토마토")
+    private String nickname;
+
+    @Schema(description = "새 프로필 이미지 URL (1~6 사이의 숫자)", example = "3")
+    private String profileImageUrl;
+
+}

--- a/src/main/java/com/example/dzipsa/domain/user/dto/response/ProfileImageResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/user/dto/response/ProfileImageResponse.java
@@ -1,0 +1,18 @@
+package com.example.dzipsa.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileImageResponse {
+
+    @Schema(description = "프로필 이미지 URL (1~6 사이의 숫자)", example = "3")
+    private String profileImageUrl;
+
+}

--- a/src/main/java/com/example/dzipsa/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/user/dto/response/UserResponse.java
@@ -20,7 +20,7 @@ public class UserResponse {
     private ProviderType providerType;
     private String profileImageUrl;
     private UserRole role;
-    private boolean terms_agreed;
+    private boolean termsAgreed;
     private boolean hasRoom;
 
 }

--- a/src/main/java/com/example/dzipsa/domain/user/entity/User.java
+++ b/src/main/java/com/example/dzipsa/domain/user/entity/User.java
@@ -53,7 +53,7 @@ public class User {
 
     private String profileImageUrl;
 
-    private boolean terms_agreed;
+    private boolean termsAgreed;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
@@ -86,6 +86,11 @@ public class User {
     public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void agreeTerms() {
+        this.termsAgreed = true;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/example/dzipsa/domain/user/service/UserService.java
+++ b/src/main/java/com/example/dzipsa/domain/user/service/UserService.java
@@ -1,52 +1,13 @@
 package com.example.dzipsa.domain.user.service;
 
-import com.example.dzipsa.domain.room.repository.RoomMemberRepository;
-import com.example.dzipsa.domain.user.converter.UserConverter;
+import com.example.dzipsa.domain.user.dto.request.UpdateProfileRequest;
+import com.example.dzipsa.domain.user.dto.response.ProfileImageResponse;
 import com.example.dzipsa.domain.user.dto.response.UserResponse;
-import com.example.dzipsa.domain.user.entity.User;
-import com.example.dzipsa.domain.user.repository.UserRepository;
-import com.example.dzipsa.global.exception.BusinessException;
-import com.example.dzipsa.global.exception.domain.UserErrorCode;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-@Slf4j
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class UserService {
-
-    private final UserRepository userRepository;
-    private final UserConverter userConverter;
-    private final RoomMemberRepository roomMemberRepository;
-
-    public UserResponse findById(Long userId) {
-        log.debug("[UserService] findById userId={}", userId);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.warn("[UserService] findById 실패 - 사용자 없음 userId={}", userId);
-                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
-                });
-        
-        boolean hasRoom = roomMemberRepository.findByUserIdAndLeftAtIsNull(userId).isPresent();
-        
-        return userConverter.toResponse(user, hasRoom);
-    }
-
-    public UserResponse findByEmail(String email) {
-        log.debug("[UserService] findByEmail email={}", email);
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> {
-                    log.warn("[UserService] findByEmail 실패 - 사용자 없음 email={}", email);
-                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
-                });
-        
-        boolean hasRoom = roomMemberRepository.findByUserIdAndLeftAtIsNull(user.getId()).isPresent();
-        
-        return userConverter.toResponse(user, hasRoom);
-    }
+public interface UserService {
+    UserResponse findById(Long userId);
+    UserResponse findByEmail(String email);
+    ProfileImageResponse getProfileImage(Long userId);
+    void agreeTerms(Long userId);
+    UserResponse updateProfile(Long userId, UpdateProfileRequest request);
 }

--- a/src/main/java/com/example/dzipsa/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/dzipsa/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,120 @@
+package com.example.dzipsa.domain.user.service;
+
+import com.example.dzipsa.domain.room.repository.RoomMemberRepository;
+import com.example.dzipsa.domain.room.service.RoomService;
+import com.example.dzipsa.domain.user.converter.UserConverter;
+import com.example.dzipsa.domain.user.dto.request.UpdateProfileRequest;
+import com.example.dzipsa.domain.user.dto.response.ProfileImageResponse;
+import com.example.dzipsa.domain.user.dto.response.UserResponse;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.domain.user.repository.UserRepository;
+import com.example.dzipsa.global.exception.BusinessException;
+import com.example.dzipsa.global.exception.domain.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserConverter userConverter;
+    private final RoomMemberRepository roomMemberRepository;
+    private final RoomService roomService;
+
+    @Override
+    public UserResponse findById(Long userId) {
+        log.debug("[UserServiceImpl] findById userId={}", userId);
+        User user = getUserById(userId);
+        
+        boolean hasRoom = checkHasRoom(userId);
+        
+        return userConverter.toResponse(user, hasRoom);
+    }
+
+    @Override
+    public UserResponse findByEmail(String email) {
+        log.debug("[UserServiceImpl] findByEmail email={}", email);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn("[UserServiceImpl] findByEmail 실패 - 사용자 없음 email={}", email);
+                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                });
+        
+        boolean hasRoom = checkHasRoom(user.getId());
+        
+        return userConverter.toResponse(user, hasRoom);
+    }
+
+    @Override
+    public ProfileImageResponse getProfileImage(Long userId) {
+        log.debug("[UserServiceImpl] getProfileImage userId={}", userId);
+        User user = getUserById(userId);
+        return userConverter.toProfileImageResponse(user);
+    }
+
+    @Override
+    @Transactional
+    public void agreeTerms(Long userId) {
+        log.debug("[UserServiceImpl] agreeTerms userId={}", userId);
+        User user = getUserById(userId);
+        
+        if (user.isTermsAgreed()) {
+            log.warn("[UserServiceImpl] 이미 이용약관에 동의함. userId={}", userId);
+            throw new BusinessException(UserErrorCode.ALREADY_AGREED_TERMS);
+        }
+        
+        user.agreeTerms();
+    }
+
+    @Override
+    @Transactional
+    public UserResponse updateProfile(Long userId, UpdateProfileRequest request) {
+        log.debug("[UserServiceImpl] updateProfile userId={}, nickname={}, profileImageUrl={}",
+                userId, request.getNickname(), request.getProfileImageUrl());
+        User user = getUserById(userId);
+
+        // 방 구성원과 프로필 이미지 중복 검증
+        validateUniqueProfileImageInRoom(user, request.getProfileImageUrl());
+
+        user.updateProfile(request.getNickname(), request.getProfileImageUrl());
+
+        boolean hasRoom = checkHasRoom(userId);
+        return userConverter.toResponse(user, hasRoom);
+    }
+
+    private void validateUniqueProfileImageInRoom(User user, String newProfileImageUrl) {
+        if (newProfileImageUrl == null || newProfileImageUrl.isBlank() || newProfileImageUrl.equals(user.getProfileImageUrl())) {
+            return;
+        }
+
+        if (checkHasRoom(user.getId())) {
+            List<String> usedImages = roomService.getUsedProfileImages(user, null).getUsedImages();
+            if (usedImages.contains(newProfileImageUrl)) {
+                log.warn("[UserServiceImpl] 프로필 이미지 중복 - 방의 다른 구성원이 사용 중: userId={}, profileImageUrl={}",
+                        user.getId(), newProfileImageUrl);
+                throw new BusinessException(UserErrorCode.DUPLICATED_PROFILE_IMAGE);
+            }
+        }
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("[UserServiceImpl] 사용자 조회 실패 userId={}", userId);
+                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                });
+    }
+
+    private boolean checkHasRoom(Long userId) {
+        return roomMemberRepository.findByUserIdAndLeftAtIsNull(userId).isPresent();
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/exception/domain/UserErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/UserErrorCode.java
@@ -12,7 +12,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ApiCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다."),
-    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 사용 중인 닉네임입니다.");
+    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 사용 중인 닉네임입니다."),
+    DUPLICATED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST.value(), 400, "방 구성원과 중복된 프로필 이미지입니다."),
+    ALREADY_AGREED_TERMS(HttpStatus.BAD_REQUEST.value(), 400, "이미 이용약관에 동의한 사용자입니다.");
 
     private final Integer httpStatus;
     private final Integer code;


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#18 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

- UserController: 사용자 프로필 조회, 수정 및 약관 동의 API 구현
- UserService: 사용자 정보 조회, 프로필 수정 및 약관 동의 로직 추가
- DTO: UpdateProfileRequest, ProfileImageResponse 추가
- User: 약관 동의 상태 업데이트 메서드 추가, snake_case -> camelCase로 변경
- Converter: `toProfileImageResponse` 메서드 추가

## 🛠️ 주요 변경 사항 및 리팩토링


## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
