### PR TITLE
방 생성 API의 파라미터에서 @Valid 어노테이션 제거 

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/dzipsa/domain/room/controller/RoomController.java
@@ -33,7 +33,7 @@ public class RoomController {
     @PostMapping
     @Operation(summary = "방 생성", description = "방 생성 후 24시간 유효한 6자리 초대 코드가 반환됩니다.")
     public ResponseEntity<RoomResponse> createRoom(
-            @Valid @RequestBody(required = false) RoomCreateRequest request,
+            @RequestBody(required = false) RoomCreateRequest request,
             @AuthenticationPrincipal User user) {
         RoomResponse response = roomService.create(request, user);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#23

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

RoomController: createRoom 메서드의 RoomCreateRequest 파라미터(required = false)에 적용된 불필요한 `@Valid` 어노테이션 제거

## 🛠️ 주요 변경 사항 및 리팩토링


## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
