### PR TITLE
Rule 도메인 개발

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/rule/controller/RuleController.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/controller/RuleController.java
@@ -1,0 +1,95 @@
+package com.example.dzipsa.domain.rule.controller;
+
+import com.example.dzipsa.domain.rule.dto.request.RuleCreateRequest;
+import com.example.dzipsa.domain.rule.dto.request.RuleUpdateRequest;
+import com.example.dzipsa.domain.rule.dto.response.RuleListResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleWarningResponse;
+import com.example.dzipsa.domain.rule.service.RuleService;
+import com.example.dzipsa.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Rules", description = "규칙 관련 API")
+@RestController
+@RequestMapping("/api/rules")
+@RequiredArgsConstructor
+public class RuleController {
+
+    private final RuleService ruleService;
+
+    @PostMapping
+    @Operation(summary = "규칙 등록", description = "방장만 규칙을 등록할 수 있습니다.")
+    public ResponseEntity<RuleResponse> createRule(
+            @Valid @RequestBody RuleCreateRequest request,
+            @AuthenticationPrincipal User user) {
+        RuleResponse response = ruleService.createRule(request, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{ruleId}")
+    @Operation(summary = "규칙 수정", description = "방장만 규칙을 수정할 수 있습니다.")
+    public ResponseEntity<RuleResponse> updateRule(
+            @PathVariable Long ruleId,
+            @Valid @RequestBody RuleUpdateRequest request,
+            @AuthenticationPrincipal User user) {
+        RuleResponse response = ruleService.updateRule(ruleId, request, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{ruleId}")
+    @Operation(summary = "규칙 상세 조회")
+    public ResponseEntity<RuleResponse> getRule(
+            @PathVariable Long ruleId,
+            @AuthenticationPrincipal User user) {
+        RuleResponse response = ruleService.getRule(ruleId, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "규칙 목록 조회", description = "최신 등록순으로 정렬되며 무한 스크롤(Cursor 방식)이 적용됩니다.")
+    public ResponseEntity<List<RuleListResponse>> getRules(
+            @Parameter(description = "마지막으로 조회된 규칙 ID (첫 조회 시 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "조회할 개수 (기본값: 10)")
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal User user) {
+        List<RuleListResponse> response = ruleService.getRules(cursor, size, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{ruleId}")
+    @Operation(summary = "규칙 삭제", description = "방장만 규칙을 삭제할 수 있습니다.")
+    public ResponseEntity<Void> deleteRule(
+            @PathVariable Long ruleId,
+            @AuthenticationPrincipal User user) {
+        ruleService.deleteRule(ruleId, user);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{ruleId}/warnings")
+    @Operation(summary = "집사에게 알리기(경고) 등록", description = "규칙을 지키지 않았을 때 멤버가 알림을 보냅니다. 알리기 시 해당 규칙은 24시간 동안 비활성화됩니다.")
+    public ResponseEntity<RuleWarningResponse> createWarning(
+            @PathVariable Long ruleId,
+            @AuthenticationPrincipal User user) {
+        RuleWarningResponse response = ruleService.createWarning(ruleId, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/warnings/recent")
+    @Operation(summary = "최근 알리기(경고) 목록 조회", description = "알리기가 생성된 지 24시간 이내인 알리기 중 최근 3개를 조회합니다.")
+    public ResponseEntity<List<RuleWarningResponse>> getRecentWarnings(
+            @AuthenticationPrincipal User user) {
+        List<RuleWarningResponse> response = ruleService.getRecentWarnings(user);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/converter/RuleConverter.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/converter/RuleConverter.java
@@ -1,0 +1,107 @@
+package com.example.dzipsa.domain.rule.converter;
+
+import com.example.dzipsa.domain.rule.dto.request.RuleCreateRequest;
+import com.example.dzipsa.domain.rule.dto.response.RuleListResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleWarningResponse;
+import com.example.dzipsa.domain.rule.entity.Rule;
+import com.example.dzipsa.domain.rule.entity.RuleWarning;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Component
+public class RuleConverter {
+
+    private static final LocalTime DEFAULT_START_TIME = LocalTime.of(9, 0);
+    private static final LocalTime DEFAULT_END_TIME = LocalTime.of(0, 0); // 24:00 is 00:00
+
+    public Rule toRule(RuleCreateRequest request, Long roomId, Long userId) {
+        LocalTime startTime = request.getStartTime();
+        LocalTime endTime = request.getEndTime();
+
+        if (request.isTimeSettingEnabled()) {
+            if (startTime == null) startTime = DEFAULT_START_TIME;
+            if (endTime == null) endTime = DEFAULT_END_TIME;
+        } else {
+            startTime = null;
+            endTime = null;
+        }
+
+        String repeatDays = request.isRepeatEnabled() ? normalizeRepeatDays(request.getRepeatDays()) : null;
+
+        return Rule.builder()
+                .roomId(roomId)
+                .registerId(userId)
+                .title(request.getTitle())
+                .memo(request.getMemo())
+                .timeSettingEnabled(request.isTimeSettingEnabled())
+                .startTime(startTime)
+                .endTime(endTime)
+                .repeatEnabled(request.isRepeatEnabled())
+                .repeatDays(repeatDays)
+                .notiEnabled(request.isNotiEnabled())
+                .build();
+    }
+
+    public RuleResponse toRuleResponse(Rule rule, boolean isWarningDisabled) {
+        return toRuleResponse(rule, isWarningDisabled, false);
+    }
+
+    public RuleResponse toRuleResponse(Rule rule, boolean isWarningDisabled, boolean isDetail) {
+        return RuleResponse.builder()
+                .id(rule.getId())
+                .roomId(rule.getRoomId())
+                .registerId(rule.getRegisterId())
+                .title(rule.getTitle())
+                .memo(rule.getMemo())
+                .timeSettingEnabled(rule.isTimeSettingEnabled())
+                .startTime(rule.getStartTime())
+                .endTime(rule.getEndTime())
+                .repeatEnabled(rule.isRepeatEnabled())
+                .repeatDays(rule.getRepeatDays())
+                .notiEnabled(rule.isNotiEnabled())
+                .warningDisabled(isWarningDisabled)
+                .build();
+    }
+
+    public RuleListResponse toRuleListResponse(Rule rule, boolean isWarningDisabled) {
+        return RuleListResponse.builder()
+                .id(rule.getId())
+                .roomId(rule.getRoomId())
+                .registerId(rule.getRegisterId())
+                .title(rule.getTitle())
+                .memo(rule.getMemo())
+                .timeSettingEnabled(rule.isTimeSettingEnabled())
+                .startTime(rule.getStartTime())
+                .endTime(rule.getEndTime())
+                .repeatEnabled(rule.isRepeatEnabled())
+                .repeatDays(rule.getRepeatDays())
+                .warningDisabled(isWarningDisabled)
+                .build();
+    }
+
+    public String normalizeRepeatDays(String repeatDays) {
+        if (repeatDays == null || repeatDays.isBlank()) {
+            return null;
+        }
+        return Arrays.stream(repeatDays.split(","))
+                .map(String::trim)
+                .filter(day -> !day.isBlank())
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining(","));
+    }
+
+    public RuleWarningResponse toRuleWarningResponse(RuleWarning warning, String ruleTitle) {
+        return RuleWarningResponse.builder()
+                .id(warning.getId())
+                .roomId(warning.getRoomId())
+                .ruleId(warning.getRuleId())
+                .ruleTitle(ruleTitle)
+                .createdAt(warning.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/dto/request/RuleCreateRequest.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/dto/request/RuleCreateRequest.java
@@ -1,0 +1,41 @@
+package com.example.dzipsa.domain.rule.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class RuleCreateRequest {
+
+    @NotBlank(message = "규칙 제목은 필수입니다.")
+    @Size(max = 30, message = "규칙 제목은 최대 30자까지 가능합니다.")
+    @Schema(description = "규칙 제목", example = "분리수거 하기")
+    private String title;
+
+    @Size(max = 300, message = "메모는 최대 300자까지 가능합니다.")
+    @Schema(description = "메모", example = "매주 화요일 저녁")
+    private String memo;
+
+    @Schema(description = "시간 설정 여부", example = "true")
+    private boolean timeSettingEnabled;
+
+    @Schema(description = "시작 시간", example = "09:00:00")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "12:00:00")
+    private LocalTime endTime;
+
+    @Schema(description = "반복 설정 여부 (false: 매일, true: 설정 요일)", example = "false")
+    private boolean repeatEnabled;
+
+    @Schema(description = "반복 요일 목록 (1:월 ~ 7:일)", example = "1,3,5")
+    private String repeatDays;
+
+    @Schema(description = "알림 설정 여부", example = "true")
+    private boolean notiEnabled;
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/dto/request/RuleUpdateRequest.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/dto/request/RuleUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.example.dzipsa.domain.rule.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class RuleUpdateRequest {
+
+    @NotBlank(message = "규칙 제목은 필수입니다.")
+    @Size(max = 30, message = "규칙 제목은 최대 30자까지 가능합니다.")
+    @Schema(description = "규칙 제목", example = "분리수거 하기 수정")
+    private String title;
+
+    @Size(max = 300, message = "메모는 최대 300자까지 가능합니다.")
+    @Schema(description = "메모", example = "매주 수요일 저녁으로 변경")
+    private String memo;
+
+    @Schema(description = "시간 설정 여부", example = "true")
+    private boolean timeSettingEnabled;
+
+    @Schema(description = "시작 시간", example = "10:00:00")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "13:00:00")
+    private LocalTime endTime;
+
+    @Schema(description = "반복 설정 여부", example = "true")
+    private boolean repeatEnabled;
+
+    @Schema(description = "반복 요일 목록 (1:월 ~ 7:일)", example = "1,3,5")
+    private String repeatDays;
+
+    @Schema(description = "알림 설정 여부", example = "true")
+    private boolean notiEnabled;
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/dto/response/RuleListResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/dto/response/RuleListResponse.java
@@ -1,0 +1,49 @@
+package com.example.dzipsa.domain.rule.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RuleListResponse {
+
+    @Schema(description = "규칙 ID")
+    private Long id;
+
+    @Schema(description = "방 ID")
+    private Long roomId;
+
+    @Schema(description = "등록자 ID")
+    private Long registerId;
+
+    @Schema(description = "규칙 제목")
+    private String title;
+
+    @Schema(description = "메모")
+    private String memo;
+
+    @Schema(description = "시간 설정 여부")
+    private boolean timeSettingEnabled;
+
+    @Schema(description = "시작 시간")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간")
+    private LocalTime endTime;
+
+    @Schema(description = "반복 설정 여부")
+    private boolean repeatEnabled;
+
+    @Schema(description = "반복 요일 목록 (1:월 ~ 7:일)", example = "1,3,5")
+    private String repeatDays;
+
+    @Schema(description = "집사에게 알리기 비활성화 여부 (24시간 내 이미 알린 경우 true)")
+    private boolean warningDisabled;
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/dto/response/RuleResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/dto/response/RuleResponse.java
@@ -1,0 +1,52 @@
+package com.example.dzipsa.domain.rule.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RuleResponse {
+
+    @Schema(description = "규칙 ID")
+    private Long id;
+
+    @Schema(description = "방 ID")
+    private Long roomId;
+
+    @Schema(description = "등록자 ID")
+    private Long registerId;
+
+    @Schema(description = "규칙 제목")
+    private String title;
+
+    @Schema(description = "메모")
+    private String memo;
+
+    @Schema(description = "시간 설정 여부")
+    private boolean timeSettingEnabled;
+
+    @Schema(description = "시작 시간")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간")
+    private LocalTime endTime;
+
+    @Schema(description = "반복 설정 여부")
+    private boolean repeatEnabled;
+
+    @Schema(description = "반복 요일 목록 (1:월 ~ 7:일)", example = "1,3,5")
+    private String repeatDays;
+
+    @Schema(description = "알림 설정 여부")
+    private boolean notiEnabled;
+
+    @Schema(description = "집사에게 알리기 비활성화 여부 (24시간 내 이미 알린 경우 true)")
+    private boolean warningDisabled;
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/dto/response/RuleWarningResponse.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/dto/response/RuleWarningResponse.java
@@ -1,0 +1,31 @@
+package com.example.dzipsa.domain.rule.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RuleWarningResponse {
+
+    @Schema(description = "경고 ID")
+    private Long id;
+
+    @Schema(description = "방 ID")
+    private Long roomId;
+
+    @Schema(description = "규칙 ID")
+    private Long ruleId;
+
+    @Schema(description = "규칙 제목")
+    private String ruleTitle;
+
+    @Schema(description = "생성 일시")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/entity/Rule.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/entity/Rule.java
@@ -1,0 +1,100 @@
+package com.example.dzipsa.domain.rule.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "rules")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Rule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long roomId;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long registerId;
+
+    @NotBlank
+    @Size(max = 30)
+    @Column(nullable = false, length = 30)
+    private String title;
+
+    @Size(max = 300)
+    @Column(length = 300)
+    private String memo;
+
+    @Column(nullable = false)
+    private boolean timeSettingEnabled;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    @Column(nullable = false)
+    private boolean repeatEnabled;
+
+    @Size(max = 50)
+    @Column(length = 50)
+    private String repeatDays; // 1,2... (1:월, 7:일)
+
+    @Column(nullable = false)
+    private boolean notiEnabled;
+
+    @NotNull
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public Rule(Long roomId, Long registerId, String title, String memo,
+                boolean timeSettingEnabled, LocalTime startTime, LocalTime endTime,
+                boolean repeatEnabled, String repeatDays, boolean notiEnabled) {
+        this.roomId = roomId;
+        this.registerId = registerId;
+        this.title = title;
+        this.memo = memo;
+        this.timeSettingEnabled = timeSettingEnabled;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.repeatEnabled = repeatEnabled;
+        this.repeatDays = repeatDays;
+        this.notiEnabled = notiEnabled;
+    }
+
+    public void update(String title, String memo, boolean timeSettingEnabled, LocalTime startTime, LocalTime endTime,
+                       boolean repeatEnabled, String repeatDays, boolean notiEnabled) {
+        this.title = title;
+        this.memo = memo;
+        this.timeSettingEnabled = timeSettingEnabled;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.repeatEnabled = repeatEnabled;
+        this.repeatDays = repeatDays;
+        this.notiEnabled = notiEnabled;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/entity/RuleWarning.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/entity/RuleWarning.java
@@ -1,0 +1,43 @@
+package com.example.dzipsa.domain.rule.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "rule_warnings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class RuleWarning {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long roomId;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long ruleId;
+
+    @NotNull
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RuleWarning(Long roomId, Long ruleId) {
+        this.roomId = roomId;
+        this.ruleId = ruleId;
+    }
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/repository/RuleRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/repository/RuleRepository.java
@@ -1,0 +1,18 @@
+package com.example.dzipsa.domain.rule.repository;
+
+import com.example.dzipsa.domain.rule.entity.Rule;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RuleRepository extends JpaRepository<Rule, Long> {
+    
+    Optional<Rule> findByIdAndDeletedAtIsNull(Long id);
+
+    @Query("SELECT r FROM Rule r WHERE r.roomId = :roomId AND r.deletedAt IS NULL AND (:cursor IS NULL OR r.id < :cursor) ORDER BY r.id DESC")
+    List<Rule> findByRoomIdWithCursor(@Param("roomId") Long roomId, @Param("cursor") Long cursor, Pageable pageable);
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/repository/RuleWarningRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/repository/RuleWarningRepository.java
@@ -1,0 +1,18 @@
+package com.example.dzipsa.domain.rule.repository;
+
+import com.example.dzipsa.domain.rule.entity.RuleWarning;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface RuleWarningRepository extends JpaRepository<RuleWarning, Long> {
+    
+    boolean existsByRuleIdAndCreatedAtAfter(Long ruleId, LocalDateTime createdAt);
+    
+    List<RuleWarning> findByRoomIdAndCreatedAtAfterOrderByCreatedAtDesc(Long roomId, LocalDateTime createdAt, Pageable pageable);
+
+    Optional<RuleWarning> findFirstByRuleIdOrderByCreatedAtDesc(Long ruleId);
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/service/RuleService.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/service/RuleService.java
@@ -1,0 +1,21 @@
+package com.example.dzipsa.domain.rule.service;
+
+import com.example.dzipsa.domain.rule.dto.request.RuleCreateRequest;
+import com.example.dzipsa.domain.rule.dto.request.RuleUpdateRequest;
+import com.example.dzipsa.domain.rule.dto.response.RuleListResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleWarningResponse;
+import com.example.dzipsa.domain.user.entity.User;
+
+import java.util.List;
+
+public interface RuleService {
+    RuleResponse createRule(RuleCreateRequest request, User user);
+    RuleResponse updateRule(Long ruleId, RuleUpdateRequest request, User user);
+    RuleResponse getRule(Long ruleId, User user);
+    List<RuleListResponse> getRules(Long cursor, int size, User user);
+    void deleteRule(Long ruleId, User user);
+    
+    RuleWarningResponse createWarning(Long ruleId, User user);
+    List<RuleWarningResponse> getRecentWarnings(User user);
+}

--- a/src/main/java/com/example/dzipsa/domain/rule/service/RuleServiceImpl.java
+++ b/src/main/java/com/example/dzipsa/domain/rule/service/RuleServiceImpl.java
@@ -1,0 +1,195 @@
+package com.example.dzipsa.domain.rule.service;
+
+import com.example.dzipsa.domain.room.entity.RoomMember;
+import com.example.dzipsa.domain.room.repository.RoomMemberRepository;
+import com.example.dzipsa.domain.room.repository.RoomRepository;
+import com.example.dzipsa.domain.rule.converter.RuleConverter;
+import com.example.dzipsa.domain.rule.dto.request.RuleCreateRequest;
+import com.example.dzipsa.domain.rule.dto.request.RuleUpdateRequest;
+import com.example.dzipsa.domain.rule.dto.response.RuleListResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleResponse;
+import com.example.dzipsa.domain.rule.dto.response.RuleWarningResponse;
+import com.example.dzipsa.domain.rule.entity.Rule;
+import com.example.dzipsa.domain.rule.entity.RuleWarning;
+import com.example.dzipsa.domain.rule.repository.RuleRepository;
+import com.example.dzipsa.domain.rule.repository.RuleWarningRepository;
+import com.example.dzipsa.domain.user.entity.User;
+import com.example.dzipsa.global.exception.BusinessException;
+import com.example.dzipsa.global.exception.domain.RoomErrorCode;
+import com.example.dzipsa.global.exception.domain.RuleErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RuleServiceImpl implements RuleService {
+
+    private final RuleRepository ruleRepository;
+    private final RuleWarningRepository ruleWarningRepository;
+    private final RoomMemberRepository roomMemberRepository;
+    private final RoomRepository roomRepository;
+    private final RuleConverter ruleConverter;
+
+    @Override
+    @Transactional
+    public RuleResponse createRule(RuleCreateRequest request, User user) {
+        log.info("[RuleService] 규칙 생성 요청. userId={}", user.getId());
+        RoomMember myMember = getActiveRoomMember(user.getId());
+
+        if (request.isNotiEnabled() && !request.isTimeSettingEnabled()) {
+            throw new BusinessException(RuleErrorCode.NOTI_NOT_AVAILABLE_WITHOUT_TIME);
+        }
+
+        Rule rule = ruleConverter.toRule(request, myMember.getRoomId(), user.getId());
+        ruleRepository.save(rule);
+
+        return ruleConverter.toRuleResponse(rule, false);
+    }
+
+    @Override
+    @Transactional
+    public RuleResponse updateRule(Long ruleId, RuleUpdateRequest request, User user) {
+        log.info("[RuleService] 규칙 수정 요청. ruleId={}, userId={}", ruleId, user.getId());
+        Rule rule = findRuleById(ruleId);
+
+        if (request.isNotiEnabled() && !request.isTimeSettingEnabled()) {
+            throw new BusinessException(RuleErrorCode.NOTI_NOT_AVAILABLE_WITHOUT_TIME);
+        }
+
+        String repeatDays = request.isRepeatEnabled() ? ruleConverter.normalizeRepeatDays(request.getRepeatDays()) : null;
+
+        LocalTime startTime = request.getStartTime();
+        LocalTime endTime = request.getEndTime();
+        if (request.isTimeSettingEnabled()) {
+            if (startTime == null) startTime = LocalTime.of(9, 0);
+            if (endTime == null) endTime = LocalTime.of(0, 0);
+        } else {
+            startTime = null;
+            endTime = null;
+        }
+
+        rule.update(
+                request.getTitle(),
+                request.getMemo(),
+                request.isTimeSettingEnabled(),
+                startTime,
+                endTime,
+                request.isRepeatEnabled(),
+                repeatDays,
+                request.isNotiEnabled()
+        );
+
+        return ruleConverter.toRuleResponse(rule, isWarningDisabled(rule.getId()));
+    }
+
+    @Override
+    public RuleResponse getRule(Long ruleId, User user) {
+        log.info("[RuleService] 규칙 단건 조회 요청. ruleId={}, userId={}", ruleId, user.getId());
+        Rule rule = findRuleById(ruleId);
+        RoomMember myMember = getActiveRoomMember(user.getId());
+
+        if (!rule.getRoomId().equals(myMember.getRoomId())) {
+            throw new BusinessException(RoomErrorCode.NOT_ROOM_MEMBER);
+        }
+
+        return ruleConverter.toRuleResponse(rule, isWarningDisabled(rule.getId()));
+    }
+
+    @Override
+    public List<RuleListResponse> getRules(Long cursor, int size, User user) {
+        log.info("[RuleService] 규칙 목록 조회 요청. userId={}, cursor={}, size={}", user.getId(), cursor, size);
+        RoomMember myMember = getActiveRoomMember(user.getId());
+        
+        List<Rule> rules = ruleRepository.findByRoomIdWithCursor(myMember.getRoomId(), cursor, PageRequest.of(0, size));
+        
+        return rules.stream()
+                .map(rule -> ruleConverter.toRuleListResponse(rule, isWarningDisabled(rule.getId())))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteRule(Long ruleId, User user) {
+        log.info("[RuleService] 규칙 삭제 요청. ruleId={}, userId={}", ruleId, user.getId());
+        Rule rule = findRuleById(ruleId);
+
+        rule.delete();
+    }
+
+    @Override
+    @Transactional
+    public RuleWarningResponse createWarning(Long ruleId, User user) {
+        log.info("[RuleService] 집사에게 알리기(경고) 등록 요청. ruleId={}, userId={}", ruleId, user.getId());
+        Rule rule = findRuleById(ruleId);
+        RoomMember myMember = getActiveRoomMember(user.getId());
+        
+        if (!rule.getRoomId().equals(myMember.getRoomId())) {
+             throw new BusinessException(RoomErrorCode.NOT_ROOM_MEMBER);
+        }
+
+        if (isWarningDisabled(ruleId)) {
+            throw new BusinessException(RuleErrorCode.ALREADY_WARNED);
+        }
+
+        RuleWarning warning = RuleWarning.builder()
+                .roomId(rule.getRoomId())
+                .ruleId(rule.getId())
+                .build();
+        ruleWarningRepository.save(warning);
+
+        return ruleConverter.toRuleWarningResponse(warning, rule.getTitle());
+    }
+
+    @Override
+    public List<RuleWarningResponse> getRecentWarnings(User user) {
+        log.info("[RuleService] 최근 알리기 목록 조회 요청. userId={}", user.getId());
+        RoomMember myMember = getActiveRoomMember(user.getId());
+        
+        LocalDateTime last24Hours = LocalDateTime.now().minusHours(24);
+        List<RuleWarning> warnings = ruleWarningRepository.findByRoomIdAndCreatedAtAfterOrderByCreatedAtDesc(
+                myMember.getRoomId(), last24Hours, PageRequest.of(0, 3));
+
+        return warnings.stream()
+                .map(w -> {
+                    Rule rule = ruleRepository.findByIdAndDeletedAtIsNull(w.getRuleId()).orElse(null);
+                    String title = (rule != null) ? rule.getTitle() : "삭제된 규칙";
+                    return ruleConverter.toRuleWarningResponse(w, title);
+                })
+                .filter(response -> !response.getRuleTitle().equals("삭제된 규칙"))
+                .collect(Collectors.toList());
+    }
+
+    private Rule findRuleById(Long ruleId) {
+        return ruleRepository.findByIdAndDeletedAtIsNull(ruleId)
+                .orElseThrow(() -> new BusinessException(RuleErrorCode.RULE_NOT_FOUND));
+    }
+
+    private RoomMember getActiveRoomMember(Long userId) {
+        return roomMemberRepository.findByUserIdAndLeftAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(RoomErrorCode.ROOM_NOT_FOUND));
+    }
+
+    private void validateRoomOwner(Long roomId, Long userId) {
+        roomRepository.findByIdAndDeletedAtIsNull(roomId)
+                .ifPresent(room -> {
+                    if (!room.getOwnerId().equals(userId)) {
+                        throw new BusinessException(RuleErrorCode.FORBIDDEN_NOT_OWNER);
+                    }
+                });
+    }
+
+    private boolean isWarningDisabled(Long ruleId) {
+        LocalDateTime last24Hours = LocalDateTime.now().minusHours(24);
+        return ruleWarningRepository.existsByRuleIdAndCreatedAtAfter(ruleId, last24Hours);
+    }
+}

--- a/src/main/java/com/example/dzipsa/global/exception/domain/RuleErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/RuleErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.dzipsa.global.exception.domain;
+
+import com.example.dzipsa.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RuleErrorCode implements ApiCode {
+    RULE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 40410, "해당 규칙을 찾을 수 없습니다."),
+    FORBIDDEN_NOT_OWNER(HttpStatus.FORBIDDEN.value(), 40310, "방장만 규칙을 관리할 수 있습니다."),
+    ALREADY_WARNED(HttpStatus.BAD_REQUEST.value(), 40010, "이미 24시간 내에 알리기를 수행한 규칙입니다."),
+    NOTI_NOT_AVAILABLE_WITHOUT_TIME(HttpStatus.BAD_REQUEST.value(), 40011, "시간 설정이 없는 경우 알림 기능을 사용할 수 없습니다.");
+
+    private final Integer httpStatus;
+    private final Integer code;
+    private final String message;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#31
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

규칙(Rule) 및 집사에게 알리기(Warning) 기능 구현
- Controller: 규칙 CRUD, 무한 스크롤(Cursor 방식) 목록 조회, 집사에게 알리기 API 및 Swagger 명세 추가
- Service/Converter: 규칙 생성/수정/삭제 로직, 24시간 내 알림 중복 방지, 시간/알림 유효성 검증 및 DTO 변환 구현
- Entity/Repository: Rule 및 RuleWarning 엔티티 추가, Soft Delete 적용 및 커서 기반 페이징 쿼리 작성
- DTO: 규칙 및 알리기 데이터 처리용 Request/Response 객체 구현 (시간, 반복, 알림 설정 등 포함)
- Exception: 규칙 도메인 전용 에러 코드(RuleErrorCode) 추가 (조회 불가, 방장 권한 부족, 중복 알림, 설정 누락 등 예외 처리)
## 🛠️ 주요 변경 사항 및 리팩토링


## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
