### PR TITLE
User 엔티티 유효성 검증 제약 조건 추가

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/user/entity/User.java
+++ b/src/main/java/com/example/dzipsa/domain/user/entity/User.java
@@ -4,16 +4,10 @@ import com.example.dzipsa.domain.auth.entity.enums.ProviderType;
 import com.example.dzipsa.domain.user.entity.enums.UserRole;
 import com.example.dzipsa.domain.user.entity.enums.UserStatus;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,17 +30,22 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // unique = true 제거됨
+    @NotBlank
+    @Size(max = 100)
     @Column(nullable = false, length = 100)
     private String email;
 
-    @Column(nullable = false, length = 50)
+    @NotBlank
+    @Size(min = 2, max = 20)
+    @Column(nullable = false, length = 20)
     private String nickname;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private UserStatus status;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
@@ -60,6 +59,7 @@ public class User {
     private ProviderType providerType;
 
 
+    @NotNull
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;


### PR DESCRIPTION


## 🔗 관련 이슈
> e.g. Close #이슈번호

#35 
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

## 🛠️ 주요 변경 사항 및 리팩토링
- User: email, nickname, status, role, createdAt 필드에 `@NotBlank`, `@NotNull`, `@Size` 등의 유효성 검증 어노테이션 추가
- nickname 필드의 데이터베이스 컬럼 길이를 50에서 20으로 축소
- jakarta.persistence 패키지 import 구문 최적화

## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
