### PR TITLE
도메인별 예외 에러 코드 체계 개편 및 그룹화

### DIFF
--- a/src/main/java/com/example/dzipsa/global/exception/domain/AuthErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/AuthErrorCode.java
@@ -11,11 +11,18 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AuthErrorCode implements ApiCode {
 
-    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 존재하는 이메일입니다."),
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), 401, "아이디 또는 비밀번호가 잘못되었습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), 401, "유효하지 않은 리프레시 토큰입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED.value(), 401, "로그인이 필요합니다.");
+    // --- 4xx Client Errors ---
+
+    // 400 Bad Request
+    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 140001, "이미 존재하는 이메일입니다."),
+
+    // 401 Unauthorized
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), 140101, "아이디 또는 비밀번호가 잘못되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), 140102, "유효하지 않은 리프레시 토큰입니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED.value(), 140103, "로그인이 필요합니다."),
+
+    // 404 Not Found
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 140401, "존재하지 않는 유저입니다.");
 
     private final Integer httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/dzipsa/global/exception/domain/RoomErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/RoomErrorCode.java
@@ -8,16 +8,29 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum RoomErrorCode implements ApiCode {
-    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 40401, "해당 방을 찾을 수 없습니다."),
-    FORBIDDEN_NOT_OWNER(HttpStatus.FORBIDDEN.value(), 40301, "방장만 이 작업을 수행할 수 있습니다."),
-    INVALID_INVITATION_CODE(HttpStatus.BAD_REQUEST.value(), 40001, "유효하지 않은 초대 코드입니다."),
-    INVITATION_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), 50001, "초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
-    NOT_ROOM_MEMBER(HttpStatus.FORBIDDEN.value(), 40302, "해당 방의 멤버가 아닙니다."),
-    ALREADY_ROOM_MEMBER(HttpStatus.BAD_REQUEST.value(), 40002, "이미 해당 방에 참여 중입니다."),
-    ALREADY_HAS_ROOM(HttpStatus.BAD_REQUEST.value(), 40003, "이미 참여 중인 방이 있습니다."),
-    ROOM_IS_FULL(HttpStatus.BAD_REQUEST.value(), 40004, "방의 최대 인원(6명)을 초과할 수 없습니다."),
-    CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST.value(), 40005, "자기 자신을 내보낼 수 없습니다."),
-    REISSUE_COOLDOWN_ACTIVE(HttpStatus.BAD_REQUEST.value(), 40006, "초대 코드 재발급은 1시간에 한 번만 가능합니다.");
+    // --- 4xx Client Errors ---
+
+    // 400 Bad Request
+    INVALID_INVITATION_CODE(HttpStatus.BAD_REQUEST.value(), 340001, "유효하지 않은 초대 코드입니다."),
+    ALREADY_ROOM_MEMBER(HttpStatus.BAD_REQUEST.value(), 340002, "이미 해당 방에 참여 중입니다."),
+    ALREADY_HAS_ROOM(HttpStatus.BAD_REQUEST.value(), 340003, "이미 참여 중인 방이 있습니다."),
+    ROOM_IS_FULL(HttpStatus.BAD_REQUEST.value(), 340004, "방의 최대 인원(6명)을 초과할 수 없습니다."),
+    CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST.value(), 340005, "자기 자신을 내보낼 수 없습니다."),
+    REISSUE_COOLDOWN_ACTIVE(HttpStatus.BAD_REQUEST.value(), 340006, "초대 코드 재발급은 1시간에 한 번만 가능합니다."),
+
+    // 403 Forbidden
+    FORBIDDEN_NOT_OWNER(HttpStatus.FORBIDDEN.value(), 340301, "방장만 이 작업을 수행할 수 있습니다."),
+    NOT_ROOM_MEMBER(HttpStatus.FORBIDDEN.value(), 340302, "해당 방의 멤버가 아닙니다."),
+
+    // 404 Not Found
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 340401, "해당 방을 찾을 수 없습니다."),
+
+
+    // --- 5xx Server Errors ---
+
+    // 500 Internal Server Error
+    INVITATION_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), 350001, "초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
+
 
     private final Integer httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/dzipsa/global/exception/domain/RuleErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/RuleErrorCode.java
@@ -8,10 +8,18 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum RuleErrorCode implements ApiCode {
-    RULE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 40410, "해당 규칙을 찾을 수 없습니다."),
-    FORBIDDEN_NOT_OWNER(HttpStatus.FORBIDDEN.value(), 40310, "방장만 규칙을 관리할 수 있습니다."),
-    ALREADY_WARNED(HttpStatus.BAD_REQUEST.value(), 40010, "이미 24시간 내에 알리기를 수행한 규칙입니다."),
-    NOTI_NOT_AVAILABLE_WITHOUT_TIME(HttpStatus.BAD_REQUEST.value(), 40011, "시간 설정이 없는 경우 알림 기능을 사용할 수 없습니다.");
+    // --- 4xx Client Errors ---
+
+    // 400 Bad Request
+    ALREADY_WARNED(HttpStatus.BAD_REQUEST.value(), 440001, "이미 24시간 내에 알리기를 수행한 규칙입니다."),
+    NOTI_NOT_AVAILABLE_WITHOUT_TIME(HttpStatus.BAD_REQUEST.value(), 440002, "시간 설정이 없는 경우 알림 기능을 사용할 수 없습니다."),
+
+    // 403 Forbidden
+    FORBIDDEN_NOT_OWNER(HttpStatus.FORBIDDEN.value(), 440301, "방장만 규칙을 관리할 수 있습니다."),
+
+    // 404 Not Found
+    RULE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 440401, "해당 규칙을 찾을 수 없습니다.");
+
 
     private final Integer httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/dzipsa/global/exception/domain/UserErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/UserErrorCode.java
@@ -11,10 +11,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum UserErrorCode implements ApiCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다."),
-    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 사용 중인 닉네임입니다."),
-    DUPLICATED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST.value(), 400, "방 구성원과 중복된 프로필 이미지입니다."),
-    ALREADY_AGREED_TERMS(HttpStatus.BAD_REQUEST.value(), 400, "이미 이용약관에 동의한 사용자입니다.");
+    // --- 4xx Client Errors ---
+
+    // 400 Bad Request
+    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 240001, "이미 사용 중인 닉네임입니다."),
+    DUPLICATED_PROFILE_IMAGE(HttpStatus.BAD_REQUEST.value(), 240002, "방 구성원과 중복된 프로필 이미지입니다."),
+    ALREADY_AGREED_TERMS(HttpStatus.BAD_REQUEST.value(), 240003, "이미 이용약관에 동의한 사용자입니다."),
+
+    // 404 Not Found
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 240401, "존재하지 않는 유저입니다.");
 
     private final Integer httpStatus;
     private final Integer code;


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#46
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>


## 🛠️ 주요 변경 사항 및 리팩토링
공통: 에러 코드를 6자리(도메인 + HTTP 상태 코드 + 일련번호) 구조로 통일하고 HTTP 상태 코드(400, 401, 403, 404, 500)를 기준으로 주석과 함께 그룹화하여 가독성 개선
- AuthErrorCode: 1xxxxx 대역 에러 코드 적용
- UserErrorCode: 2xxxxx 대역 에러 코드 적용
- RoomErrorCode: 3xxxxx 대역 에러 코드 적용
- RuleErrorCode: 4xxxxx 대역 에러 코드 적용

## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
