### PR TITLE
소셜 로그인 가입 및 재가입 시 닉네임 null 처리

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/dzipsa/domain/auth/service/CustomOAuth2UserService.java
@@ -88,7 +88,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             // 2-1. 이메일과 Provider가 모두 일치하고, 상태가 DELETED인 경우 -> 재가입 처리
             if (existingUser.getStatus() == UserStatus.DELETED) {
                 log.info("[CustomOAuth2UserService] 탈퇴한 사용자 재가입 처리. userId={}", existingUser.getId());
-                existingUser.rejoin(userInfo.getNickname());
+                // 닉네임이 null인 경우 "임시닉네임" 문자열로 대체
+                String nickname = userInfo.getNickname() != null ? userInfo.getNickname() : "임시닉네임";
+                existingUser.rejoin(nickname);
                 createOAuthAccount(existingUser, provider, userInfo.getProviderId());
                 return existingUser;
             }
@@ -106,9 +108,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private User createUserAndOAuthAccount(OAuth2UserInfo userInfo, OAuthProvider provider) {
         log.info("[CustomOAuth2UserService] 신규 사용자 가입 처리. email={}, provider={}", userInfo.getEmail(), provider.name());
+        
+        // 닉네임이 null인 경우 "임시닉네임" 문자열로 대체
+        String nickname = userInfo.getNickname() != null ? userInfo.getNickname() : "임시닉네임";
+        
         User newUser = User.builder()
                 .email(userInfo.getEmail())
-                .nickname(userInfo.getNickname())
+                .nickname(nickname)
                 .status(UserStatus.ACTIVE)
                 .providerType(ProviderType.valueOf(userInfo.getProvider().toUpperCase()))
                 .build();


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#52
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

소셜 로그인 가입 및 재가입 시 닉네임 null 처리

## 🛠️ 주요 변경 사항 및 리팩토링
- CustomOAuth2UserService: 신규 가입 및 탈퇴한 사용자 재가입 시, 제공받은 닉네임이 없을(null) 경우 "임시닉네임"을 기본값으로 부여하도록 로직 수정

## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
