### PR TITLE
feat: 개발 환경 (Dev) 자동 배포 파이프라인 및 전용 설정 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,63 @@
+name: Spring Boot Deploy to EC2 (DEV)
+
+# dev 브랜치에 push 될 때만 작동하도록 설정
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. 내 코드 가져오기 (Checkout)
+        uses: actions/checkout@v3
+
+      - name: 2. JDK 17 환경 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: 3. Gradle 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 4. Spring Boot 애플리케이션 빌드 (테스트 제외)
+        run: ./gradlew clean build -x test
+
+      # 운영 서버의 app.jar와 겹치지 않도록 이름을 app-dev.jar로 고정합니다.
+      - name: 5. 빌드 파일 이름 변경
+        run: mv build/libs/*SNAPSHOT.jar build/libs/app-dev.jar
+
+      - name: 6. 빌드된 파일(.jar)을 EC2로 전송
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "build/libs/app-dev.jar" # 변경된 이름으로 전송
+          target: "/home/ubuntu/develop"
+
+      - name: 7. EC2에 접속해서 기존 개발 서버 끄고 새 개발 서버 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ubuntu/develop
+            
+            echo "기존 개발 서버를 안전하게 종료합니다."
+            sudo fuser -k -n tcp 8081 || true  # 운영 서버(8080)가 아닌 개발 서버(8081) 포트 종료
+            
+            # 포트가 완전히 해제될 때까지 5초 대기
+            sleep 5
+            
+            # 개발용 .env.dev 환경변수 적용 
+            set -a
+            source .env.dev
+            set +a
+            
+            echo "새로운 개발 서버를 백그라운드에서 실행합니다."
+            # app-dev.jar를 dev 프로필로 실행하고 로그도 분리
+            nohup java -jar -Dspring.profiles.active=dev build/libs/app-dev.jar > app-dev.log 2>&1 &

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,7 +32,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-      database: 0  # 운영 서버는 0번 방을 사용하도록 격리
+      database: 1  # 개발 서버는 1번 방을 사용하도록 격리
 
   # OAuth2
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8081 # 개발 서버는 8081 포트를 사용하도록 변경
+  port: 8080 # 운영 서버는 8080 포트를 사용
 
 spring:
   application:


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#65
## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

이슈에서 논의된 개발 환경 자동 배포 구축 및 운영 환경과의 리소스 격리를 완료했습니다
## 🛠️ 주요 변경 사항 및 리팩토링
- `.github/workflows/deploy-dev.yml`: `develop` 브랜치용 Actions 스크립트 작성 (`app-dev.jar`로 빌드 및 실행)
- `application-dev.yml`: `dev` 프로필 전용 설정 (DB, OAuth2, JWT, S3 환경변수) 추가
  - **격리 설정**: 운영과 충돌하지 않도록 **Redis DB를 1번으로 변경**하고, 서버 포트를 **8081**로 지정
- `application.yml`: 기본 설정 명시 (Redis 0번 DB 등)

## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
- 개발 서버는 `8081` 포트로 구동됩니다.