### PR TITLE
지연된 할 일 수정 시 데이터 중복 생성 오류 수정

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/com/example/dzipsa/domain/todo/service/TodoServiceImpl.java
@@ -144,6 +144,16 @@ public class TodoServiceImpl implements TodoService {
         ? request.getTargetDate()
         : request.getStartDate();
 
+    // 삭제 기준일 설정: 현재 DB에 저장된 인스턴스의 날짜와 수정 요청된 날짜 중 가장 과거를 기준으로 삭제 범위를 잡음
+    // 지연된 할 일(과거)을 수정할 수도 있으므로, 오늘과 입력받은 targetDate 중 더 과거인 날짜를 기준으로 삭제
+    LocalDate today = LocalDate.now();
+    LocalDate deleteBasisDate = today;
+
+    // 만약 수정하려는 타겟 날짜가 오늘보다 이전(지연된 할 일)이라면 해당 날짜부터 삭제 범위를 확장
+    if (request.getTargetDate() != null && request.getTargetDate().isBefore(today)) {
+      deleteBasisDate = request.getTargetDate();
+    }
+
     // 3. Todo 마스터 정보 업데이트
     todo.update(
         request.getTitle(),
@@ -157,20 +167,23 @@ public class TodoServiceImpl implements TodoService {
     );
 
     // 기존 미래 인스턴스(오늘 포함) 정리 후 재생성
-    todoInstanceRepository.deleteFutureInstances(todo.getId(), LocalDate.now());
+    // deleteBasisDate를 전달하여 지연된 과거 데이터부터 싹 밀어버림
+    todoInstanceRepository.deleteFutureInstances(todo.getId(), deleteBasisDate);
 
     // 4. 요일이나 규칙이 바뀌었을 수 있으므로 배치 서비스를 호출해 인스턴스들을 재정비
+    TodoInstance representInstance = null;
     if (todo.getRecurringType() == RecurringType.NONE) {
       // 반복 없음: 수정된 targetDate에 단일 생성
-      saveInstance(todo, todo.getRoom(), newAssignee, request.getTargetDate());
+      representInstance = saveInstance(todo, todo.getRoom(), newAssignee, request.getTargetDate());
     } else {
       // 오늘부터 향후 14일간의 데이터를 수정된 규칙에 맞게 생성/갱신
-      todoBatchService.generateInstancesRange(todo, LocalDate.now(), LocalDate.now().plusDays(14));
-    }
+      // 생성 시작점은 오늘로 잡아야 중복 생성 및 과거 불필요 데이터 생성을 방지함
+      todoBatchService.generateInstancesRange(todo, today, today.plusDays(14));
 
-    // 5. 수정한 직후 오늘 수행해야 할 인스턴스가 있는지 다시 조회
-    TodoInstance representInstance = todoInstanceRepository.findByTodoIdAndTargetDate(todo.getId(), LocalDate.now())
-        .orElse(null);
+      // 수정한 직후 오늘 수행해야 할 인스턴스가 있는지 다시 조회
+      representInstance = todoInstanceRepository.findByTodoIdAndTargetDate(todo.getId(), today)
+          .orElse(null);
+    }
 
     // 응답용 targetDate 직접 계산 (로직 분리)
     LocalDate responseTargetDate = (representInstance != null)


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#82 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

- 지연된 할 일(과거 데이터)을 수정할 때, 기존 데이터가 삭제되지 않고 새 데이터가 추가로 생성되어 목록에 중복 노출되는 버그 해결

- 원인 분석: 기존 삭제 로직이 LocalDate.now()를 기준으로만 동작하여, 오늘보다 이전 날짜인 지연된 할 일은 삭제 대상에서 누락됨

- 해결 방법: 삭제 기준일을 Math.min(오늘, 수정 날짜)로 동적 설정하여 과거 데이터부터 안전하게 밀어버리도록 로직 개선

- 결과: 지연된 할 일 수정 후에도 데이터 정합성이 유지되어 단일 데이터만 노출됨


## 🛠️ 주요 변경 사항 및 리팩토링
1. TodoServiceImpl.updateTodo 로직 개선
- 삭제 기준일(deleteBasisDate) 도입: 수정 요청 시 들어온 targetDate가 오늘보다 이전일 경우, 해당 과거 날짜를 기준으로 인스턴스 정리(deleteFutureInstances)를 수행

- 생성 범위 최적화: 인스턴스 자동 생성(generateInstancesRange) 시 시작점을 오늘로 설정하여, 과거의 불필요한 반복 데이터가 생성되는 것을 방지

2. TodoInstanceRepository 쿼리 안정성 강화
deleteFutureInstances: 삭제 조건에 status = 'PENDING'을 추가하여, 기획 요건에 따라 이미 완료된(COMPLETED) 과거 데이터는 삭제되지 않도록 보호 장치를 마련


## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

테스트 완료 케이스

오늘 할 일 수정 -> 정상 (1건 유지)

예정된 할 일 수정 -> 정상 (1건 유지)

지연된 할 일(3/22) 수정 -> 기존 3/22 데이터 삭제 및 신규 1건 생성 확인 (성공)
