### PR TITLE
할 일(Todo) 도메인 보안 및 데이터 정합성 로직 강화

### DIFF
--- a/src/main/java/com/example/dzipsa/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/example/dzipsa/domain/room/service/RoomServiceImpl.java
@@ -14,6 +14,8 @@ import com.example.dzipsa.domain.room.repository.RoomInvitationRepository;
 import com.example.dzipsa.domain.room.repository.RoomMemberRepository;
 import com.example.dzipsa.domain.room.repository.RoomRepository;
 import com.example.dzipsa.domain.rule.repository.RuleWarningRepository;
+import com.example.dzipsa.domain.todo.entity.enums.TodoStatus;
+import com.example.dzipsa.domain.todo.repository.TodoInstanceRepository;
 import com.example.dzipsa.domain.todo.service.TodoService;
 import com.example.dzipsa.domain.user.entity.User;
 import com.example.dzipsa.domain.user.repository.UserRepository;
@@ -43,6 +45,7 @@ public class RoomServiceImpl implements RoomService {
     private final RuleWarningRepository ruleWarningRepository;
     private final RoomConverter roomConverter;
     private final TodoService todoService;
+    private final TodoInstanceRepository todoInstanceRepository;
 
     @Override
     @Transactional
@@ -180,6 +183,7 @@ public class RoomServiceImpl implements RoomService {
         // 2. 퇴장 처리 (Soft Delete)
         me.leave();
         room.decreaseMemberCount();
+        todoInstanceRepository.deletePendingInstancesByUserIdAndRoomId(user.getId(), room.getId(), TodoStatus.PENDING);
         log.info("[RoomService] 방 나가기 완료. roomId={}, userId={}", room.getId(), user.getId());
     }
 
@@ -289,6 +293,7 @@ public class RoomServiceImpl implements RoomService {
         // 퇴장 처리
         targetMember.leave();
         room.decreaseMemberCount();
+        todoInstanceRepository.deletePendingInstancesByUserIdAndRoomId(memberUserId, room.getId(), TodoStatus.PENDING);
         log.info("[RoomService] 구성원 내보내기 완료. targetUserId={}, roomId={}", memberUserId, room.getId());
     }
 

--- a/src/main/java/com/example/dzipsa/domain/todo/repository/TodoInstanceRepository.java
+++ b/src/main/java/com/example/dzipsa/domain/todo/repository/TodoInstanceRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional; // 추가
 
 import java.time.LocalDate;
 import java.util.List;
@@ -72,7 +73,6 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
 
   /**
    * [우리집 할 일 - 오늘 할 일 - 무한 스크롤]
-   * 상태(status) 필터를 추가하여 '완료'된 항목 등을 제외할 수 있음
    */
   @Query("SELECT ti FROM TodoInstance ti WHERE ti.room.id = :roomId AND ti.targetDate = :today " +
       "AND ti.status = :status AND ti.id > :cursorId " +
@@ -129,14 +129,12 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
 
   /**
    * [우리집 할 일 - 상단 넛지 통계용 (오늘 전체 리스트)]
-   * 에러 해결: 서비스에서 호출하는 인자 2개 버전 유지 (오늘 전체 할 일 개수 계산용)
    */
   @Query("SELECT ti FROM TodoInstance ti WHERE ti.room.id = :roomId AND ti.targetDate = :today")
   List<TodoInstance> findRoomTodayTodos(@Param("roomId") Long roomId, @Param("today") LocalDate today);
 
   /**
    * [우리집 할 일 - 상단 넛지 통계용 (상태 필터링 포함)]
-   * 특정 상태의 오늘 할 일 리스트를 가져올 때 사용
    */
   @Query("SELECT ti FROM TodoInstance ti WHERE ti.room.id = :roomId " +
       "AND ti.targetDate = :today AND ti.status = :status")
@@ -154,8 +152,6 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
 
   /**
    * [완료된 할 일 조회 - 무한 스크롤]
-   * 정렬 기준: completedAt DESC (최신 완료순)
-   * 커서: 완료일시_ID (LocalDateTime_Long)
    */
   @Query("SELECT ti FROM TodoInstance ti WHERE ti.room.id = :roomId " +
       "AND ti.status = :status " +
@@ -179,10 +175,6 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
   List<TodoInstance> findAllByRoomIdAndStatusNot(Long roomId, TodoStatus status);
   List<TodoInstance> findAllByTodoIdAndTargetDateAfter(Long todoId, LocalDate today);
 
-  /**
-   * [우리집 할 일 - 지연된 할 일 개수 조회]
-   * 오늘 이전이면서 완료되지 않은(PENDING/DELAYED 등) 할 일의 개수
-   */
   @Query("SELECT COUNT(ti) FROM TodoInstance ti WHERE ti.room.id = :roomId " +
       "AND ti.targetDate < :today AND ti.status = :status")
   long countRoomDelayedTodos(
@@ -191,10 +183,6 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
       @Param("status") TodoStatus status
   );
 
-  /**
-   * [우리집 할 일 - 모든 할 일 개수 조회]
-   * 특정 상태(예: DELETED 등)를 제외한 모든 할 일의 개수
-   */
   @Query("SELECT COUNT(ti) FROM TodoInstance ti WHERE ti.room.id = :roomId " +
       "AND ti.status != :status")
   long countRoomAllTodos(
@@ -202,16 +190,9 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
       @Param("status") TodoStatus status
   );
 
-  /**
-   * [구성원 통계용] 특정 담당자의 모든 미완료 할 일 개수 (날짜 상관없음)
-   */
   @Query("SELECT COUNT(ti) FROM TodoInstance ti WHERE ti.actualAssignee.id = :userId AND ti.status = :status")
   int countTotalPendingByMember(@Param("userId") Long userId, @Param("status") TodoStatus status);
 
-  /**
-   * [할 일 삭제 - SINCE_THIS]
-   * 특정 날짜 이후의 미완료(PENDING) 인스턴스들을 물리 삭제
-   */
   @Modifying
   @Query("DELETE FROM TodoInstance ti WHERE ti.todo.id = :todoId " +
       "AND ti.targetDate >= :targetDate AND ti.status = :status")
@@ -221,14 +202,23 @@ public interface TodoInstanceRepository extends JpaRepository<TodoInstance, Long
       @Param("status") TodoStatus status
   );
 
-  /**
-   * [할 일 삭제 - ALL_RECURRING]
-   * 해당 Todo의 모든 미완료(PENDING) 인스턴스들을 물리 삭제
-   */
   @Modifying
   @Query("DELETE FROM TodoInstance ti WHERE ti.todo.id = :todoId AND ti.status = :status")
   void deleteAllByTodoIdAndStatus(
       @Param("todoId") Long todoId,
+      @Param("status") TodoStatus status
+  );
+
+  // 방 나가기 시 해당 유저의 PENDING 할 일 물리 삭제
+  @Modifying
+  @Transactional
+  @Query("DELETE FROM TodoInstance ti " +
+      "WHERE ti.actualAssignee.id = :userId " +
+      "AND ti.room.id = :roomId " +
+      "AND ti.status = :status")
+  void deletePendingInstancesByUserIdAndRoomId(
+      @Param("userId") Long userId,
+      @Param("roomId") Long roomId,
       @Param("status") TodoStatus status
   );
 }

--- a/src/main/java/com/example/dzipsa/domain/todo/service/TodoServiceImpl.java
+++ b/src/main/java/com/example/dzipsa/domain/todo/service/TodoServiceImpl.java
@@ -63,14 +63,13 @@ public class TodoServiceImpl implements TodoService {
     // 날짜 유효성 검증 (시작일이 종료일보다 늦으면 예외 발생)
     validateTodoDates(request.getStartDate(), request.getEndDate());
 
-    // 1. 기본 설정 및 Todo 저장
+    // 1. 내 방 정보 조회
     RoomMember myMember = getActiveRoomMember(user.getId());
     Room myRoom = findRoomById(myMember.getRoomId());
 
-    User targetAssignee = (request.getAssigneeId() != null)
-        ? userRepository.findById(request.getAssigneeId())
-        .orElseThrow(() -> new BusinessException(TodoErrorCode.ASSIGNEE_NOT_FOUND))
-        : user;
+    // 담당자 유효성 검증 및 요일/날짜 형식 검증 추가
+    User targetAssignee = validateAndGetAssignee(request.getAssigneeId(), myRoom.getId(), user);
+    validateRepeatDays(request.getRecurringType(), request.getRepeatDays());
 
     // 반복 여부에 따른 시작 날짜 결정 (NONE이면 targetDate가 곧 시작일)
     LocalDate finalStartDate = (request.getRecurringType() == RecurringType.NONE)
@@ -133,11 +132,9 @@ public class TodoServiceImpl implements TodoService {
     Todo todo = todoRepository.findById(todoId)
         .orElseThrow(() -> new BusinessException(TodoErrorCode.TODO_NOT_FOUND));
 
-    // 2. 담당자 확인
-    User newAssignee = (request.getAssigneeId() != null)
-        ? userRepository.findById(request.getAssigneeId())
-        .orElseThrow(() -> new BusinessException(TodoErrorCode.ASSIGNEE_NOT_FOUND))
-        : todo.getDefaultAssignee();
+    // 담당자 유효성 검증 (해당 방의 멤버인지) 및 형식 검증 추가
+    User newAssignee = validateAndGetAssignee(request.getAssigneeId(), todo.getRoom().getId(), todo.getDefaultAssignee());
+    validateRepeatDays(request.getRecurringType(), request.getRepeatDays());
 
     // 수정 시 반복 여부에 따른 시작 날짜 재결정
     LocalDate finalStartDate = (request.getRecurringType() == RecurringType.NONE)
@@ -707,6 +704,42 @@ public class TodoServiceImpl implements TodoService {
     boolean isAssignee = instance.getActualAssignee().getId().equals(userId);
     if (!isAssignee) {
       throw new BusinessException(TodoErrorCode.FORBIDDEN_DELETE);
+    }
+  }
+
+  /**
+   * 담당자가 해당 방에 실제로 참여 중인 멤버인지 검증
+   */
+  private User validateAndGetAssignee(Long assigneeId, Long roomId, User fallbackUser) {
+    if (assigneeId == null) return fallbackUser;
+
+    User assignee = userRepository.findById(assigneeId)
+        .orElseThrow(() -> new BusinessException(TodoErrorCode.ASSIGNEE_NOT_FOUND));
+
+    // 해당 유저가 해당 방의 활성 멤버인지 체크
+    boolean isMember = roomMemberRepository.findByRoomIdAndUserIdAndLeftAtIsNull(roomId, assigneeId).isPresent();
+    if (!isMember) {
+      log.warn("[TodoService] 방 멤버가 아닌 유저를 담당자로 지정 시도. roomId={}, userId={}", roomId, assigneeId);
+      throw new BusinessException(TodoErrorCode.ASSIGNEE_NOT_IN_ROOM);
+    }
+
+    return assignee;
+  }
+
+  /**
+   * 반복 설정에 따른 repeatDays 값의 형식 유효성 검사 (정규식 활용)
+   */
+  private void validateRepeatDays(RecurringType type, String repeatDays) {
+    if (type == RecurringType.WEEKLY) {
+      // 주간 반복: "1,2,3" 형식 (1~7 숫자와 쉼표만 허용)
+      if (repeatDays == null || !repeatDays.matches("^[1-7](,[1-7])*$")) {
+        throw new BusinessException(TodoErrorCode.INVALID_REPEAT_DAYS);
+      }
+    } else if (type == RecurringType.MONTHLY) {
+      // 월간 반복: "1" ~ "31" 사이의 숫자 문자열만 허용
+      if (repeatDays == null || !repeatDays.matches("^([1-9]|[12][0-9]|3[01])$")) {
+        throw new BusinessException(TodoErrorCode.INVALID_REPEAT_DAYS);
+      }
     }
   }
 }

--- a/src/main/java/com/example/dzipsa/global/exception/domain/TodoErrorCode.java
+++ b/src/main/java/com/example/dzipsa/global/exception/domain/TodoErrorCode.java
@@ -13,11 +13,13 @@ public enum TodoErrorCode implements ApiCode {
   // 400 Bad Request
   INVALID_RECURRING_PARS(HttpStatus.BAD_REQUEST.value(), 540001, "반복 설정 파라미터가 유효하지 않습니다."),
   INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST.value(), 540002, "종료일은 시작일보다 빠를 수 없습니다."),
+  INVALID_REPEAT_DAYS(HttpStatus.BAD_REQUEST.value(), 540003, "반복 요일 또는 날짜 형식이 올바르지 않습니다. (예: 주간 '1,2', 월간 '15')"),
 
   // 403 Forbidden
   FORBIDDEN_UPDATE_LIMIT(HttpStatus.FORBIDDEN.value(), 540301, "본인에게 할당된 할 일만 상태를 변경하거나 완료할 수 있습니다."),
   FORBIDDEN_IMAGE_DELETE(HttpStatus.FORBIDDEN.value(), 540302, "본인이 등록한 인증샷만 삭제할 수 있습니다."),
   FORBIDDEN_DELETE(HttpStatus.FORBIDDEN.value(), 540303, "담당자만 해당 할 일을 삭제할 수 있습니다."),
+  ASSIGNEE_NOT_IN_ROOM(HttpStatus.FORBIDDEN.value(), 540304, "해당 방에 소속된 멤버만 담당자로 지정할 수 있습니다."),
 
   // 404 Not Found
   TODO_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 540401, "해당 할 일 마스터 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호
#85 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

- 할 일 도메인의 데이터 무결성을 보장하기 위해 방 퇴장 시 데이터 정리와 입력값 검증 로직을 강화

- 방 탈퇴/강퇴 시 데이터 자동 정리: 유저가 방을 나갈 때 해당 방의 미완료(PENDING) 할 일이 남지 않도록 처리

- 할 일 생성/수정 보안 강화: 방에 소속되지 않은 유저를 담당자로 지정하는 행위를 차단

- 반복 설정 데이터 검증: 요일(repeatDays) 입력 시 유효하지 않은 문자열(Mon, Tue 등)이 DB에 쌓이지 않도록 정규식 검증을 도입


## 🛠️ 주요 변경 사항 및 리팩토링
- TodoInstanceRepository: 특정 유저와 방의 PENDING 데이터를 일괄 삭제하는 쿼리 메서드 추가

- RoomServiceImpl: 유저의 자발적 퇴장(leaveRoom) 및 강퇴(kickMember) 로직 내에 할 일 삭제 프로세스 연동

- TodoServiceImpl:
  - validateAndGetAssignee: 담당자가 현재 방의 멤버인지 확인하는 보안 로직 추가
  - validateRepeatDays: 정규식을 활용해 주간/월간 반복 주기의 데이터 형식 강제

- TodoErrorCode: ASSIGNEE_NOT_IN_ROOM, INVALID_REPEAT_DAYS 등 세분화된 예외 코드 도입

## 💡 참고 사항
> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

COMPLETED 상태의 할 일은 삭제하지 않고 보존하여, 유저가 나간 후에도 과거 활동 기록(인증샷 등)을 다른 방 멤버들이 확인할 수 있도록 설계
